### PR TITLE
smurf: Allow SFP calibration to be skipped

### DIFF
--- a/src/primitives/SCUBA2/_FTS2_FORM_SPECTRUM_FROM_INTERFEROGRAM_
+++ b/src/primitives/SCUBA2/_FTS2_FORM_SPECTRUM_FROM_INTERFEROGRAM_
@@ -75,7 +75,7 @@ for my $i (1..$Frm->nfiles) {
     orac_say "Spectral Filter Profile calibration file: " . $sfp . " not found!  Skipping filter..."
   }
 
-  if ($doSfp) {$args .= "sfp=$sfp ";}
+  if ($doSfp) {$args .= "sfp=$sfp ";} else {$args .= "sfp=! ";}
   $args .= "zeropad=$zeropad ";
   $args .= "resolution=$resolution ";
 


### PR DESCRIPTION
When a spectral filter profile calibration file is not found in the default location
skip this filter.