### PR TITLE
Synchronize SVN Sinistro branch with GIT:

### DIFF
--- a/src/lib/perl5/ORAC/Frame/LCOCC.pm
+++ b/src/lib/perl5/ORAC/Frame/LCOCC.pm
@@ -226,7 +226,12 @@ sub findgroup {
     # For non biases and darks, add the filter
     if ( uc( $self->hdr( "OBSTYPE" ) ) ne 'BIAS' and
       	 uc( $self->hdr( "OBSTYPE" ) ) ne 'DARK') {
-	 $hdrgrp .= "_" . uc($self->hdr( "FILTER" ));
+	 $hdrgrp .= "_" . $self->uhdr( "ORAC_FILTER" );
+    }
+    # For biases and darks, add the molecule number
+    if ( uc( $self->hdr( "OBSTYPE" ) ) eq 'BIAS' or
+      	 uc( $self->hdr( "OBSTYPE" ) ) eq 'DARK') {
+	 $hdrgrp .= "_" . $self->hdr( "MOLNUM" );
     }
     # Add DATE-OBS if we *are* doing a science observation,
     # to ensure that they are not combined into groups
@@ -263,7 +268,7 @@ start of the next.
 =cut
 
 sub framegroupkeys {
-  return (qw/ OBSTYPE XBINNING YBINNING FILTER ORAC_OBSERVATION_NUMBER/);
+  return (qw/ OBSTYPE XBINNING YBINNING ORAC_FILTER ORAC_OBSERVATION_NUMBER/);
 }
 
 =item B<file_from_bits>

--- a/src/lib/perl5/ORAC/Frame/LCOFLI.pm
+++ b/src/lib/perl5/ORAC/Frame/LCOFLI.pm
@@ -221,18 +221,18 @@ sub findgroup {
 
     $hdrgrp .=  uc($self->hdr( "OBSTYPE" ))
                 . '_bin'
-		. $self->uhdr( "ORAC_XBINNING" )
-		.'x'
-		. $self->uhdr( "ORAC_YBINNING" );
+                . $self->uhdr( "ORAC_XBINNING" )
+                .'x'
+                . $self->uhdr( "ORAC_YBINNING" );
     # For non biases and darks, add the filter
     if ( uc( $self->hdr( "OBSTYPE" ) ) ne 'BIAS' and
-	 uc( $self->hdr( "OBSTYPE" ) ) ne 'DARK') {
-	 $hdrgrp .= "_" . $self->uhdr( "ORAC_FILTER" );
+         uc( $self->hdr( "OBSTYPE" ) ) ne 'DARK') {
+         $hdrgrp .= "_" . $self->uhdr( "ORAC_FILTER" );
     }
     # For biases and darks, add the molecule number
     if ( uc( $self->hdr( "OBSTYPE" ) ) eq 'BIAS' or
-	 uc( $self->hdr( "OBSTYPE" ) ) eq 'DARK') {
-	 $hdrgrp .= "_" . $self->hdr( "MOLNUM" );
+         uc( $self->hdr( "OBSTYPE" ) ) eq 'DARK') {
+         $hdrgrp .= "_" . $self->hdr( "MOLNUM" );
     }
     # Add DATE-OBS if we *are* doing a science observation,
     # to ensure that they are not combined into groups
@@ -355,7 +355,7 @@ Tim Jenness (timj@jach.hawaii.edu)
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014 Las Cumbres Observatory Global Telescope Inc.
+Copyright (C) 2014-2015 Las Cumbres Observatory Global Telescope Inc.
 All Rights Reserved.
 
 =cut

--- a/src/lib/perl5/ORAC/Frame/LCOSBIG.pm
+++ b/src/lib/perl5/ORAC/Frame/LCOSBIG.pm
@@ -220,18 +220,18 @@ sub findgroup {
 
     $hdrgrp .=  uc($self->hdr( "OBSTYPE" ))
                 . '_bin'
-		. $self->uhdr( "ORAC_XBINNING" )
-		.'x'
-		. $self->uhdr( "ORAC_YBINNING" );
+                . $self->uhdr( "ORAC_XBINNING" )
+                .'x'
+                . $self->uhdr( "ORAC_YBINNING" );
     # For non biases and darks, add the filter
     if ( uc( $self->hdr( "OBSTYPE" ) ) ne 'BIAS' and
-      	 uc( $self->hdr( "OBSTYPE" ) ) ne 'DARK') {
-	 $hdrgrp .= "_" . $self->hdr( "FILTER" );
+         uc( $self->hdr( "OBSTYPE" ) ) ne 'DARK') {
+         $hdrgrp .= "_" . $self->hdr( "FILTER" );
     }
     # For biases and darks, add the molecule number
     if ( uc( $self->hdr( "OBSTYPE" ) ) eq 'BIAS' or
-	 uc( $self->hdr( "OBSTYPE" ) ) eq 'DARK') {
-	 $hdrgrp .= "_" . $self->hdr( "MOLNUM" );
+         uc( $self->hdr( "OBSTYPE" ) ) eq 'DARK') {
+         $hdrgrp .= "_" . $self->hdr( "MOLNUM" );
     }
     # Add DATE-OBS if we *are* doing a science observation,
     # to ensure that they are not combined into groups
@@ -354,7 +354,7 @@ Tim Jenness (timj@jach.hawaii.edu)
 
 =head1 COPYRIGHT
 
-Copyright (C) 2013 Las Cumbres Observatory Global Telescope Inc.
+Copyright (C) 2012-2015 Las Cumbres Observatory Global Telescope Inc.
 All Rights Reserved.
 
 =cut

--- a/src/lib/perl5/ORAC/Frame/LCOSBIG_0M8.pm
+++ b/src/lib/perl5/ORAC/Frame/LCOSBIG_0M8.pm
@@ -221,13 +221,13 @@ sub findgroup {
 
     $hdrgrp .=  uc($self->hdr( "OBSTYPE" ))
                 . '_bin'
-		. $self->uhdr( "ORAC_XBINNING" )
-		.'x'
-		. $self->uhdr( "ORAC_YBINNING" );
+                . $self->uhdr( "ORAC_XBINNING" )
+                .'x'
+                . $self->uhdr( "ORAC_YBINNING" );
     # For non biases and darks, add the filter
     if ( uc( $self->hdr( "OBSTYPE" ) ) ne 'BIAS' and
-	 uc( $self->hdr( "OBSTYPE" ) ) ne 'DARK') {
-	 $hdrgrp .= "_" . $self->uhdr( "ORAC_FILTER" );
+         uc( $self->hdr( "OBSTYPE" ) ) ne 'DARK') {
+         $hdrgrp .= "_" . $self->uhdr( "ORAC_FILTER" );
     }
     # Add DATE-OBS if we *are* doing a science observation,
     # to ensure that they are not combined into groups
@@ -350,7 +350,7 @@ Tim Jenness (timj@jach.hawaii.edu)
 
 =head1 COPYRIGHT
 
-Copyright (C) 2013 Las Cumbres Observatory Global Telescope Inc.
+Copyright (C) 2013, 2015 Las Cumbres Observatory Global Telescope Inc.
 All Rights Reserved.
 
 =cut

--- a/src/lib/perl5/ORAC/Frame/LCOSINISTRO.pm
+++ b/src/lib/perl5/ORAC/Frame/LCOSINISTRO.pm
@@ -221,18 +221,18 @@ sub findgroup {
 
     $hdrgrp .=  uc($self->hdr( "OBSTYPE" ))
                 . '_bin'
-		. $self->uhdr( "ORAC_XBINNING" )
-		.'x'
-		. $self->uhdr( "ORAC_YBINNING" );
+                . $self->uhdr( "ORAC_XBINNING" )
+                .'x'
+                . $self->uhdr( "ORAC_YBINNING" );
     # For non biases and darks, add the filter
     if ( uc( $self->hdr( "OBSTYPE" ) ) ne 'BIAS' and
-	 uc( $self->hdr( "OBSTYPE" ) ) ne 'DARK') {
-	 $hdrgrp .= "_" . $self->uhdr( "ORAC_FILTER" );
+         uc( $self->hdr( "OBSTYPE" ) ) ne 'DARK') {
+         $hdrgrp .= "_" . $self->uhdr( "ORAC_FILTER" );
     }
     # For biases and darks, add the molecule number
     if ( uc( $self->hdr( "OBSTYPE" ) ) eq 'BIAS' or
-	 uc( $self->hdr( "OBSTYPE" ) ) eq 'DARK') {
-	 $hdrgrp .= "_" . $self->hdr( "MOLNUM" );
+         uc( $self->hdr( "OBSTYPE" ) ) eq 'DARK') {
+         $hdrgrp .= "_" . $self->hdr( "MOLNUM" );
     }
     # Add DATE-OBS if we *are* doing a science observation,
     # to ensure that they are not combined into groups
@@ -355,7 +355,7 @@ Tim Jenness (timj@jach.hawaii.edu)
 
 =head1 COPYRIGHT
 
-Copyright (C) 2013 Las Cumbres Observatory Global Telescope Inc.
+Copyright (C) 2013, 2015 Las Cumbres Observatory Global Telescope Inc.
 All Rights Reserved.
 
 =cut

--- a/src/lib/perl5/ORAC/Inst/Defn.pm
+++ b/src/lib/perl5/ORAC/Inst/Defn.pm
@@ -1071,7 +1071,7 @@ sub orac_determine_primitive_search_path {
     push( @path, $general_root );
 
   } elsif ($inst eq 'LCOMEROPE') {
-    push( @path, File::Spec->catdir( $root, "LCOMERPE" ) );
+    push( @path, File::Spec->catdir( $root, "LCOMEROPE" ) );
     push( @path, File::Spec->catdir( $imaging_root, "LCOMEROPE" ) );
     push( @path, File::Spec->catdir( $root, "LCOSBIG" ) );
     push( @path, File::Spec->catdir( $imaging_root, "LCOSBIG" ) );

--- a/src/primitives/imaging/LCOCC/_CALCULATE_ZEROPOINT_NULL_
+++ b/src/primitives/imaging/LCOCC/_CALCULATE_ZEROPOINT_NULL_
@@ -23,7 +23,7 @@ my $amend   = $Obj->uhdr( "ORAC_AIRMASS_END" );
 $airmass = 0.5 * ( $amstart + $amend );
 orac_print ("Mean airmass=$airmass\n");
 
-orac_warn "Astrometric fit was bad so unable to determine image zeropoint statistics.\n";
+orac_warn "Skipping determination of image zeropoint statistics.\n";
 $num_objs = -99;
 $extcor = -99.0;
 $limiting_magnitude = -99.0;

--- a/src/primitives/imaging/LCOFLI/_MAKE_DARK_FROM_GROUP_
+++ b/src/primitives/imaging/LCOFLI/_MAKE_DARK_FROM_GROUP_
@@ -20,12 +20,12 @@
 #       The main two in practice will be "median" or "mode".  The
 #       former is an weighted median.
 #       The "mode" option uses an iteratively "sigma clipped" mean which
-#     	approximates to the modal value.  ["median"]
+#       approximates to the modal value.  ["median"]
 #
 # Notes:
 #    -  This primitive is suitable for optical imaging instruments.
 #    -  Processing only occurs for dark frames, and when the steering
-#     	header MAKE_DARK is true.
+#       header MAKE_DARK is true.
 #    -  The dark is displayed.
 #
 # Tasks:
@@ -55,7 +55,7 @@ use File::Copy;
     my $obstype = $Frm->uhdr( "ORAC_OBSERVATION_TYPE");
     my $stuff = "N/A";
     if ( defined $Frm->uhdr( "MAKE_DARK" ) ) {
-	$stuff = $Frm->uhdr( "MAKE_DARK" );
+        $stuff = $Frm->uhdr( "MAKE_DARK" );
     }
 #    print "SVN DBG:$obstype $stuff\n";
     if (  $Frm->uhdr( "ORAC_OBSERVATION_TYPE" ) eq "DARK" &&
@@ -152,7 +152,7 @@ use File::Copy;
         $groupname =~ s/DARK//;
 #       print "Groupname2=$groupname\n";
         $groupname =~ s/_\d*$//;
-#	print "Groupname3=$groupname\n";
+#       print "Groupname3=$groupname\n";
         my $out = "dark_" . $Frm->uhdr("ORAC_INSTRUMENT") . "_" . $Frm->uhdr( "ORAC_UTDATE") . $groupname;
 #       print "darkname=$out\n";
 
@@ -195,7 +195,7 @@ use File::Copy;
           orac_print $Frm->file . " added to index file\n\n";
 
 # Report the status of the processing.
-	  orac_print "Frames $objlist used for dark\n";
+          orac_print "Frames $objlist used for dark\n";
 
 # If we have a final destination environment var. set, convert to fits and copy
 # files there.

--- a/src/primitives/imaging/LCOSBIG/_CREATE_RAW_FRAME_
+++ b/src/primitives/imaging/LCOSBIG/_CREATE_RAW_FRAME_
@@ -9,19 +9,27 @@
 #    Perl5
 #
 # Description:
-#    Null primitive for LCOSBIG.
+#    This primitive updates the value of the SATURATE keyword in the header.
 #
 # Notes:
 #    -  This primitive is suitable for LCOSBIG.
 #
 # Authors:
-#    MJC: Malcolm J. Currie (Starlink)
+#    TAL: Tim Lister (LCOGT)
 #
 # Copyright:
-#    Copyright (C) 2003 Particle Physics and Astronomy Research
-#    Council.  All Rights Reserved.
+#    Copyright (C) 2009-2015 Las Cumbres Observatory Global Telescope Inc.
+#    All Rights Reserved.
 #
 #-
+
+# Obtain saturation level
+my $file = $Frm->file(1);
+_GET_SATURATION_LEVEL_
+my $satlevel = $_GET_SATURATION_LEVEL_{SATURATION};
+_SET_FRAME_FITS_ITEM_ FILE=$file KEY=SATURATE VALUE=$satlevel, COMMENT=[ADU]|Saturation|level|used
+
+orac_print "Set frame saturation to $satlevel\n";
 
 # Podule
 # ======
@@ -32,7 +40,7 @@ _CREATE_RAW_FRAME_ -- Creates a raw frame in ORAC_DATA_OUT.
 
 =head1 DESCRIPTION
 
-Null primitive for LCOSBIG.
+This primitive updates the value of the SATURATE keyword in the header.
 
 =head1 NOTES
 
@@ -44,11 +52,11 @@ This primitive is suitable for LCOSBIG.
 
 =head1 AUTHORS
 
-MJC: Malcolm J. Currie (Starlink)
+TAL: Tim Lister (LCOGT)
 
 =head1 COPYRIGHT
 
-Copyright (C) 2003 Particle Physics and Astronomy Research
-Council.  All Rights Reserved.
+Copyright (C) 2009-2015 Las Cumbres Observatory Global Telescope Inc.
+All Rights Reserved.
 
 =cut

--- a/src/primitives/imaging/LCOSBIG/_GET_SATURATION_LEVEL_
+++ b/src/primitives/imaging/LCOSBIG/_GET_SATURATION_LEVEL_
@@ -25,13 +25,28 @@
 #    TAL: Tim Lister (LCOGT)
 #
 # Copyright:
-#    Copyright (C) 2009-2012 Las Cumbres Observatory Global Telescope Inc.
+#    Copyright (C) 2009-2015 Las Cumbres Observatory Global Telescope Inc.
 #    All Rights Reserved.
 #
 #-
 
-# Just use a single default for now.
-    my $saturation = 46000;
+# Check value in the header and if it's not present or 0.0, just use a single 
+# default for now.
+    my $default_saturation = 46000;
+
+    my $saturation = $Frm->hdr( "SATURATE" );
+    if ( !defined( $saturation ) ) {
+        $saturation = $default_saturation;
+        orac_print "Saturation undefined in the header of " . $Frm->file .
+                     ". Using a default of $saturation electrons.\n";
+    } else {
+        if ( $saturation == 0.0 ) {
+          $saturation = $default_saturation;
+          orac_print "Saturation bad in the header of " . $Frm->file .
+                     ". Using a default of $saturation electrons.\n";
+        }
+    }
+    
     $_GET_SATURATION_LEVEL_{SATURATION} = $saturation;
 
 # Podule
@@ -79,7 +94,7 @@ TAL: Tim Lister (LCOGT)
 
 =head1 COPYRIGHT
 
-Copyright (C) 2009-2012 Las Cumbres Observatory Global Telescope Inc.
+Copyright (C) 2009-2015 Las Cumbres Observatory Global Telescope Inc.
 All Rights Reserved.
 
 =cut

--- a/src/primitives/imaging/LCOSINISTRO/_DERIVED_PRODUCTS_
+++ b/src/primitives/imaging/LCOSINISTRO/_DERIVED_PRODUCTS_
@@ -94,6 +94,7 @@ use ORAC::Version;
                      'FL02' => '1m0-SciCam-Sinistro',
                      'FL03' => '1m0-SciCam-Sinistro',
                      'FL04' => '1m0-SciCam-Sinistro',
+                     'FL06' => '1m0-SciCam-Sinistro',
                      'FL07' => '1m0-SciCam-Sinistro',
                      'EN06' => '2m0-FLOYDS-SciCam',
                      'EM01' => '2m0-SciCam-Merope',
@@ -322,7 +323,7 @@ use ORAC::Version;
       my $pubprivate;
       my $frmdate;
       $frmdate =  $Frm->hdr( "ORACDATETIME");
-      if ( $tagid =~ /^LCOEPO|FTPEPO|HAWEPO/ || $propid =~ /^LCOEPO|FTPEPO|HAWEPO/ ) {
+      if ( $tagid =~ /^LCOEPO|FTPEPO|HAWEPO/ || $propid =~ /^LCOEPO|FTPEPO|HAWEPO|standard/ ) {
         $pubprivate = 'public';
         $pubdate = $frmdate;
       } elsif ( $propid =~ /^ENG|Engineering/ ) {

--- a/src/primitives/imaging/LCOSINISTRO/_MAKE_BIAS_FROM_GROUP_
+++ b/src/primitives/imaging/LCOSINISTRO/_MAKE_BIAS_FROM_GROUP_
@@ -20,12 +20,12 @@
 #       The main two in practice will be "median" or "mode".  The
 #       former is an weighted median.
 #       The "mode" option uses an iteratively "sigma clipped" mean which
-#     	approximates to the modal value.  ["median"]
+#       approximates to the modal value.  ["median"]
 #
 # Notes:
 #    -  This primitive is suitable for optical imaging instruments.
 #    -  Processing only occurs for bias frames, and when the steering
-#     	header MAKE_BIAS is true.
+#       header MAKE_BIAS is true.
 #    -  The bias is displayed.
 #
 # Tasks:
@@ -42,7 +42,7 @@
 #    TAL: Tim Lister (LCOGT)
 #
 # Copyright:
-#    Copyright (C) 2012 Las Cumbres Observatory Global Telescope Inc.
+#    Copyright (C) 2012, 2015 Las Cumbres Observatory Global Telescope Inc.
 #    All Rights Reserved.
 #
 #-
@@ -56,7 +56,7 @@ use File::Copy;
     my $obstype = $Frm->uhdr( "ORAC_OBSERVATION_TYPE");
     my $stuff = "N/A";
     if ( defined $Frm->uhdr( "MAKE_BIAS" ) ) {
-	$stuff = $Frm->uhdr( "MAKE_BIAS" );
+        $stuff = $Frm->uhdr( "MAKE_BIAS" );
     }
 #    print "SVN DBG:$obstype $stuff\n";
     if (  $Frm->uhdr( "ORAC_OBSERVATION_TYPE" ) eq "BIAS" &&
@@ -117,11 +117,11 @@ use File::Copy;
 # Create text file to hold the list of input files, one per line.  This
 # is needed because expanded lists of files may make the command line too
 # long for the ADAM message system.
-	unlink( "makebias.inlist$$" );
-	open( my $fh_inlist, ">makebias.inlist$$" ) ||
+        unlink( "makebias.inlist$$" );
+        open( my $fh_inlist, ">makebias.inlist$$" ) ||
           orac_throw "Unable to open makebias.inlist$$ to create a list of frames to process.  Error: $!.\n";
-	print $fh_inlist join( "\n", @objects ), "\n";
-	close( $fh_inlist );
+        print $fh_inlist join( "\n", @objects ), "\n";
+        close( $fh_inlist );
 
 # Generate the bias's name.
 # =========================
@@ -130,13 +130,13 @@ use File::Copy;
 # we can add a new primitive as was done for _GET_DARK_NAME_.
 #    _GET_BIAS_NAME_
 #    my $bias = $_GET_BIAS_NAME_{NAME};
-	my $groupname = $Frm->findgroup;
-#	print "Groupname1=$groupname\n";
-	$groupname =~ s/BIAS//;
-#	print "Groupname2=$groupname\n";
-	$groupname =~ s/_\d*$//;
-#	print "Groupname3=$groupname\n";
-	my $out = "bias_" . $Frm->uhdr("ORAC_INSTRUMENT") . "_" . $Frm->uhdr( "ORAC_UTDATE") . $groupname;
+        my $groupname = $Frm->findgroup;
+#       print "Groupname1=$groupname\n";
+        $groupname =~ s/BIAS//;
+#       print "Groupname2=$groupname\n";
+        $groupname =~ s/_\d*$//;
+#       print "Groupname3=$groupname\n";
+        my $out = "bias_" . $Frm->uhdr("ORAC_INSTRUMENT") . "_" . $Frm->uhdr( "ORAC_UTDATE") . $groupname;
 # Specify the file cycle suffix.
         my $cyclesuffix = "";
         if ( $cycleno > 0 ) {
@@ -153,55 +153,55 @@ use File::Copy;
         }
         print "Using $out as biasname\n";
 
-#	print "biasname=$out\n";
+#       print "biasname=$out\n";
 
 # Make a master bias
 # ======================
 
 # Assign the other parameters.
-	my $param1 = "method=$method zero=false";
-	my $param2 = "in='^makebias.inlist$$' out=$out"; # title=\'Master bias\'";
+        my $param1 = "method=$method zero=false";
+        my $param2 = "in='^makebias.inlist$$' out=$out"; # title=\'Master bias\'";
 
 # Median filter the raw biases to produce the biasframe.
-	$Mon{ "ccdpack_red" }->obeyw( "makebias", "$param1 $param2" );
-	unlink( "makebias.inlist$$" );
+        $Mon{ "ccdpack_red" }->obeyw( "makebias", "$param1 $param2" );
+        unlink( "makebias.inlist$$" );
 
 # Record and display the bias
 # ===========================
 
 # Set the current bias in the calibration object.
-#      	_FILE_BIAS_ FILE=$out
-	$Frm->file( $out );
+#       _FILE_BIAS_ FILE=$out
+        $Frm->file( $out );
 
-	$Cal->bias( $Frm->file );
+        $Cal->bias( $Frm->file );
 # Report the processing status.
-	orac_print $Frm->file . " filed as the current bias\n";
+        orac_print $Frm->file . " filed as the current bias\n";
 
 # Add this frame to the index of bias frames, along with its headers and
 # user headers.
-	$Cal->biasindex->add( $Frm->file, { %{ $Frm->hdr }, %{ $Frm->uhdr } } );
+        $Cal->biasindex->add( $Frm->file, { %{ $Frm->hdr }, %{ $Frm->uhdr } } );
 
 # Report the processing status.
-	orac_print $Frm->file . " added to index file\n\n";
+        orac_print $Frm->file . " added to index file\n\n";
 
 # Report the status of the processing.
-	orac_print "Frames $objlist used for bias\n";
+        orac_print "Frames $objlist used for bias\n";
 
 # If we have a final destination environment var. set, convert to fits and copy
 # files there.
-	if ( defined $ENV{FINAL_DATA_OUT} ) {
-	  $Frm->file( $out );
-	  _ADD_PIPELINE_VERSION_
-	  my $file = $Frm->file( $out );
-	  my $bias_used = 'N/A';
-	  my $dark_used = 'N/A';
-	  my $flat_used = 'N/A';
-	  my $shut_used = 'N/A';
-	  my $mask_used = $Cal->mask;
-#	   print "mask=$mask_used\n";
+        if ( defined $ENV{FINAL_DATA_OUT} ) {
+          $Frm->file( $out );
+          _ADD_PIPELINE_VERSION_
+          my $file = $Frm->file( $out );
+          my $bias_used = 'N/A';
+          my $dark_used = 'N/A';
+          my $flat_used = 'N/A';
+          my $shut_used = 'N/A';
+          my $mask_used = $Cal->mask;
+#          print "mask=$mask_used\n";
 # Check for too long length (67 is max allowed by SUBPAR)
-	  if ( length($mask_used) > 50 ) {
-	    my @mask_values = split('oracdr/', $mask_used);
+          if ( length($mask_used) > 50 ) {
+            my @mask_values = split('oracdr/', $mask_used);
 # No 'oracdr/' found in filename, must be local not from cal/. Resplit on '/'.
             if ( $#mask_values == 0 ) {
               @mask_values = split('/', $mask_used);
@@ -210,57 +210,57 @@ use File::Copy;
               $mask_used = $mask_values[1];
             }
             $mask_used =~ s/[.]sdf//;
-#	   print "mask=$mask_used\n";
-	  }
-	  my $fringe_used = 'N/A';
-	#  print "bias=$bias_used, dark=$dark_used, flat=$flat_used, shut=$shut_used, mask=$mask_used\n";
+#          print "mask=$mask_used\n";
+          }
+          my $fringe_used = 'N/A';
+        #  print "bias=$bias_used, dark=$dark_used, flat=$flat_used, shut=$shut_used, mask=$mask_used\n";
 
 # Determine processing steps done
-	  my $ovscan_correct = 0;
-	  $ovscan_correct = $Frm->uhdr( "OVSCAN_CORRECT")
-			       if(defined $Frm->uhdr( "OVSCAN_CORRECT"));
-	  my $bias_removed = -1;
-	  $bias_removed = $Frm->uhdr( "BIAS_REMOVED")
-			       if(defined $Frm->uhdr( "BIAS_REMOVED"));
-	  my $dark_removed = -1;
-	  $dark_removed = $Frm->uhdr( "DARK_REMOVED")
-			       if(defined $Frm->uhdr( "DARK_REMOVED"));
-	  my $ovscan_removed = -1;
-	  $ovscan_removed = $Frm->uhdr( "OVSCAN_REMOVED")
-			       if(defined $Frm->uhdr( "OVSCAN_REMOVED"));
-	  my $flat_removed = -1;
-	  my $fringe_removed = -1;
+          my $ovscan_correct = 0;
+          $ovscan_correct = $Frm->uhdr( "OVSCAN_CORRECT")
+                               if(defined $Frm->uhdr( "OVSCAN_CORRECT"));
+          my $bias_removed = -1;
+          $bias_removed = $Frm->uhdr( "BIAS_REMOVED")
+                               if(defined $Frm->uhdr( "BIAS_REMOVED"));
+          my $dark_removed = -1;
+          $dark_removed = $Frm->uhdr( "DARK_REMOVED")
+                               if(defined $Frm->uhdr( "DARK_REMOVED"));
+          my $ovscan_removed = -1;
+          $ovscan_removed = $Frm->uhdr( "OVSCAN_REMOVED")
+                               if(defined $Frm->uhdr( "OVSCAN_REMOVED"));
+          my $flat_removed = -1;
+          my $fringe_removed = -1;
 
-	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1STATOV VALUE=$ovscan_correct, COMMENT=Status|flag|for|overscan|correction
-	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1STATBI VALUE=$bias_removed, COMMENT=Status|flag|for|bias|frame|correction
-	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1STATDA VALUE=$dark_removed, COMMENT=Status|flag|for|dark|frame|correction
-	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1STATTR VALUE=$ovscan_removed, COMMENT=Status|flag|for|overscan|trimming
-	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1STATFL VALUE=$flat_removed, COMMENT=Status|flag|for|flat|frame|correction
-	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1STATFR VALUE=$fringe_removed, COMMENT=Status|flag|for|fringe|frame|correction
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1STATOV VALUE=$ovscan_correct, COMMENT=Status|flag|for|overscan|correction
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1STATBI VALUE=$bias_removed, COMMENT=Status|flag|for|bias|frame|correction
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1STATDA VALUE=$dark_removed, COMMENT=Status|flag|for|dark|frame|correction
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1STATTR VALUE=$ovscan_removed, COMMENT=Status|flag|for|overscan|trimming
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1STATFL VALUE=$flat_removed, COMMENT=Status|flag|for|flat|frame|correction
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1STATFR VALUE=$fringe_removed, COMMENT=Status|flag|for|fringe|frame|correction
 
-	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1IDBIAS VALUE=$bias_used, COMMENT=Id.|of|bias|frame|used
-	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1IDDARK VALUE=$dark_used, COMMENT=Id.|of|dark|frame|used
-	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1IDFLAT VALUE=$flat_used, COMMENT=Id.|of|flat|frame|used
-	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1IDSHUT VALUE=$shut_used, COMMENT=Id.|of|shutter|corr.|frame|used
-	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1IDMASK VALUE=$mask_used, COMMENT=Id.|of|mask|file|used
-	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1IDFRNG VALUE=$fringe_used, COMMENT=Id.|of|fringe|frame|used
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1IDBIAS VALUE=$bias_used, COMMENT=Id.|of|bias|frame|used
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1IDDARK VALUE=$dark_used, COMMENT=Id.|of|dark|frame|used
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1IDFLAT VALUE=$flat_used, COMMENT=Id.|of|flat|frame|used
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1IDSHUT VALUE=$shut_used, COMMENT=Id.|of|shutter|corr.|frame|used
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1IDMASK VALUE=$mask_used, COMMENT=Id.|of|mask|file|used
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1IDFRNG VALUE=$fringe_used, COMMENT=Id.|of|fringe|frame|used
 # Set image quality flag (unassessed for now)
-	  my $img_status = -1;
-	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1QIMGST VALUE=$img_status, COMMENT=Image|taking|status|(bitmask;-1=Unknown,0=OK)
+          my $img_status = -1;
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1QIMGST VALUE=$img_status, COMMENT=Image|taking|status|(bitmask;-1=Unknown,0=OK)
 
 # Set public/private flag and release date
-	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBPRV VALUE='public' COMMENT=Public|or|private|data?
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBPRV VALUE='public' COMMENT=Public|or|private|data?
 
-	  my $pubdate =  $Frm->hdr( "ORACDATETIME");
+          my $pubdate =  $Frm->hdr( "ORACDATETIME");
 #      orac_print "$pubdate\n";
-	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBDAT VALUE=$pubdate COMMENT=[UTC]|Date|the|frame|becomes|public
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBDAT VALUE=$pubdate COMMENT=[UTC]|Date|the|frame|becomes|public
 
-	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE='OPERATIONAL'
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE='OPERATIONAL'
 
 # Set recipe used
-	  my $recipe = $Frm->recipe;
+          my $recipe = $Frm->recipe;
 #      orac_print "Recipe=$recipe\n";
-	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=PCRECIPE VALUE=$recipe COMMENT=Processing|Recipes|required/used
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=PCRECIPE VALUE=$recipe COMMENT=Processing|Recipes|required/used
 
 # Set the ASN_TYPE to prevent warning in _CREATE_GRAPHIC_FROM_FILE_
               $Frm->uhdr( "ASN_TYPE", 'pub');
@@ -284,12 +284,12 @@ use File::Copy;
               }
 
 # Convert masterbias frame to FITS
-	  _CONVERT_TO_FITS_
-	  my $fitsbiasframe = $_CONVERT_TO_FITS_{FILENAME};
+          _CONVERT_TO_FITS_
+          my $fitsbiasframe = $_CONVERT_TO_FITS_{FILENAME};
 
-	  move($fitsbiasframe, $ENV{FINAL_DATA_OUT});
-	  orac_print "Moving ". $fitsbiasframe . " to final data place=" . $ENV{FINAL_DATA_OUT} . "\n";
-	}
+          move($fitsbiasframe, $ENV{FINAL_DATA_OUT});
+          orac_print "Moving ". $fitsbiasframe . " to final data place=" . $ENV{FINAL_DATA_OUT} . "\n";
+        }
 # Restore the original Frame file.
         $Frm->file( $inputfile );
 
@@ -360,7 +360,7 @@ Tim Lister (tlister@lcogt.net)
 
 =head1 COPYRIGHT
 
-Copyright (C) 2012 Las Cumbres Observatory Global Telescope Inc.
+Copyright (C) 2012, 2015 Las Cumbres Observatory Global Telescope Inc.
 All Rights Reserved.
 
 =cut

--- a/src/recipes/imaging/LCOSBIG/REDUCE_BIAS
+++ b/src/recipes/imaging/LCOSBIG/REDUCE_BIAS
@@ -24,7 +24,7 @@ Tim Lister <tlister@lcogt.net>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2011 LCOGT. All Rights Reserved.
+Copyright (C) 2011-2014 LCOGT. All Rights Reserved.
 
 =cut
 


### PR DESCRIPTION
ORAC/Frame/LCOCC.pm: Added inclusion of MOLNUM for biases and darks.
ORAC/Frame/LCOFLI.pm: Tabs removed.
ORAC/Frame/LCOSBIG_0M8.pm: Tabs removed.
ORAC/Frame/LCOSBIG.pm: Tabs removed.
ORAC/Frame/LCOSINISTRO.pm: Tabs removed.
ORAC/Inst/Defn.pm: Fix typo in LCOMEROPE primitives path.
primitives/imaging/LCOCC/_CALCULATE_ZEROPOINT_NULL_: Fix incorrect message.
primitives/imaging/LCOFLI/_MAKE_DARK_FROM_GROUP_: Tabs removed.
primitives/imaging/LCOSBIG/_CREATE_RAW_FRAME_:  Updated primitive to update the value of the SATURATE keyword in the header.
primitives/imaging/LCOSBIG/_GET_SATURATION_LEVEL_: Updated primitive to check value in the header and if it's not present or 0.0, just use the previous single default.
primitives/imaging/LCOSINISTRO/_DERIVED_PRODUCTS_: Add fl06 and make PROPID=standard data public-immediate.
primitives/imaging/LCOSINISTRO/_MAKE_BIAS_FROM_GROUP_: Tabs removed.
recipes/imaging/LCOSBIG/REDUCE_BIAS: Update copyright.