### PR TITLE
Lcogt fix for 2015 a

### DIFF
--- a/src/primitives/imaging/LCOFLI/_MAKE_DARK_FROM_GROUP_
+++ b/src/primitives/imaging/LCOFLI/_MAKE_DARK_FROM_GROUP_
@@ -42,7 +42,7 @@
 #    TAL: Tim Lister (LCOGT)
 #
 # Copyright:
-#    Copyright (C) 2012 Las Cumbres Observatory Global Telescope Inc.
+#    Copyright (C) 2012, 2015 Las Cumbres Observatory Global Telescope Inc.
 #    All Rights Reserved.
 #
 #-
@@ -271,13 +271,15 @@ use File::Copy;
             _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1QIMGST VALUE=$img_status, COMMENT=Image|taking|status|(bitmask;-1=Unknown,0=OK)
 
 # Set public/private flag and release date
-            _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBPRV VALUE='public' COMMENT=Public|or|private|data?
+            my $pubpriv = 'public';
+            _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBPRV VALUE=$pubpriv COMMENT=Public|or|private|data?
 
             my $pubdate =  $Frm->hdr( "ORACDATETIME");
 #      orac_print "$pubdate\n";
             _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBDAT VALUE=$pubdate COMMENT=[UTC]|Date|the|frame|becomes|public
 
-            _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE='OPERATIONAL'
+            my $engstate = 'OPERATIONAL';
+            _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE=$engstate
 
 # Set recipe used
             my $recipe = $Frm->recipe;
@@ -363,7 +365,7 @@ Tim Lister (tlister@lcogt.net)
 
 =head1 COPYRIGHT
 
-Copyright (C) 2012 Las Cumbres Observatory Global Telescope Inc.
+Copyright (C) 2012, 2015 Las Cumbres Observatory Global Telescope Inc.
 All Rights Reserved.
 
 =cut

--- a/src/primitives/imaging/LCOSBIG/_DERIVED_PRODUCTS_
+++ b/src/primitives/imaging/LCOSBIG/_DERIVED_PRODUCTS_
@@ -200,7 +200,8 @@ use ORAC::Version;
       my $x2 = $Frm->uhdr( "ORAC_X_UPPER_BOUND" );
       my $y1 = $Frm->uhdr( "ORAC_Y_LOWER_BOUND" );
       my $y2 = $Frm->uhdr( "ORAC_Y_UPPER_BOUND" );
-      my $trimsec = '\'[' . $x1 . ':' . $x2 . ',' . $y1 . ':' . $y2 . ']\'';
+#      my $trimsec = '\'[' . $x1 . ':' . $x2 . ',' . $y1 . ':' . $y2 . ']\'';
+      my $trimsec = '[' . $x1 . ':' . $x2 . ',' . $y1 . ':' . $y2 . ']';
 #      print "DBG: TRIMSEC=$trimsec\n";
       _SET_FILE_FITS_ITEM_ FILE=$file KEY=TRIMSEC VALUE=$trimsec, STRING=True
 
@@ -348,14 +349,12 @@ use ORAC::Version;
       _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBDAT VALUE=$pubdate COMMENT=[UTC]|Date|the|frame|becomes|public
 
       my $siteid = $Frm->hdr( "SITEID");
-      
+      my $engstate = 'COMMISSIONING';
       if ( $siteid ne "bpl" ) {
-        orac_print "SiteID=$siteid, setting to OPERATIONAL\n";
-        _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE='OPERATIONAL'
-      } else {
-        orac_print "SiteID=$siteid, setting to COMMISSIONING\n";
-        _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE='COMMISSIONING'
+        $engstate = 'OPERATIONAL';
       }
+      orac_print "SiteID=$siteid, setting to $engstate\n";
+      _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE=$engstate
 
 
 # Set recipes used

--- a/src/primitives/imaging/LCOSBIG/_IMBOX_STATS_
+++ b/src/primitives/imaging/LCOSBIG/_IMBOX_STATS_
@@ -139,3 +139,4 @@ TAL: Tim Lister (LCOGT)
 Copyright (C) 2012-2015 Las Cumbres Observatory Global Telescope Inc.
 All Rights Reserved.
 
+=cut

--- a/src/primitives/imaging/LCOSBIG/_MAKE_BIAS_FROM_GROUP_
+++ b/src/primitives/imaging/LCOSBIG/_MAKE_BIAS_FROM_GROUP_
@@ -42,7 +42,7 @@
 #    TAL: Tim Lister (LCOGT)
 #
 # Copyright:
-#    Copyright (C) 2012 Las Cumbres Observatory Global Telescope Inc.
+#    Copyright (C) 2012, 2015 Las Cumbres Observatory Global Telescope Inc.
 #    All Rights Reserved.
 #
 #-
@@ -248,13 +248,15 @@ use File::Copy;
 	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1QIMGST VALUE=$img_status, COMMENT=Image|taking|status|(bitmask;-1=Unknown,0=OK)
 
 # Set public/private flag and release date
-	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBPRV VALUE='public' COMMENT=Public|or|private|data?
+          my $pubpriv = 'public';
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBPRV VALUE=$pubpriv COMMENT=Public|or|private|data?
 
 	  my $pubdate =  $Frm->hdr( "ORACDATETIME");
 #      orac_print "$pubdate\n";
 	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBDAT VALUE=$pubdate COMMENT=[UTC]|Date|the|frame|becomes|public
 
-	  _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE='OPERATIONAL'
+          my $engstate = 'OPERATIONAL';
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE=$engstate
 
 # Set recipe used
       	  my $recipe = $Frm->recipe;
@@ -359,7 +361,7 @@ Tim Lister (tlister@lcogt.net)
 
 =head1 COPYRIGHT
 
-Copyright (C) 2012 Las Cumbres Observatory Global Telescope Inc.
+Copyright (C) 2012, 2015 Las Cumbres Observatory Global Telescope Inc.
 All Rights Reserved.
 
 =cut

--- a/src/primitives/imaging/LCOSBIG/_MAKE_DARK_FROM_GROUP_
+++ b/src/primitives/imaging/LCOSBIG/_MAKE_DARK_FROM_GROUP_
@@ -42,7 +42,7 @@
 #    TAL: Tim Lister (LCOGT)
 #
 # Copyright:
-#    Copyright (C) 2012 Las Cumbres Observatory Global Telescope Inc.
+#    Copyright (C) 2012, 2015 Las Cumbres Observatory Global Telescope Inc.
 #    All Rights Reserved.
 #
 #-
@@ -271,13 +271,15 @@ use File::Copy;
             _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1QIMGST VALUE=$img_status, COMMENT=Image|taking|status|(bitmask;-1=Unknown,0=OK)
 
 # Set public/private flag and release date
-            _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBPRV VALUE='public' COMMENT=Public|or|private|data?
+            my $pubpriv = 'public';
+            _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBPRV VALUE=$pubpriv COMMENT=Public|or|private|data?
 
             my $pubdate =  $Frm->hdr( "ORACDATETIME");
 #      orac_print "$pubdate\n";
             _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBDAT VALUE=$pubdate COMMENT=[UTC]|Date|the|frame|becomes|public
 
-            _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE='OPERATIONAL'
+            my $engstate = 'OPERATIONAL';
+            _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE=$engstate
 
 # Set recipe used
             my $recipe = $Frm->recipe;
@@ -385,7 +387,7 @@ Tim Lister (tlister@lcogt.net)
 
 =head1 COPYRIGHT
 
-Copyright (C) 2012 Las Cumbres Observatory Global Telescope Inc.
+Copyright (C) 2012, 2015 Las Cumbres Observatory Global Telescope Inc.
 All Rights Reserved.
 
 =cut

--- a/src/primitives/imaging/LCOSBIG/_MAKE_FLAT_FROM_GROUP_
+++ b/src/primitives/imaging/LCOSBIG/_MAKE_FLAT_FROM_GROUP_
@@ -397,13 +397,15 @@ use File::Copy;
               _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1QIMGST VALUE=$img_status, COMMENT=Image|taking|status|(bitmask;-1=Unknown,0=OK)
 
 # Set public/private flag and release date
-              _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBPRV VALUE='public' COMMENT=Public|or|private|data?
+              my $pubpriv = 'public';
+              _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBPRV VALUE=$pubpriv COMMENT=Public|or|private|data?
 
               my $pubdate =  $Frm->hdr( "ORACDATETIME");
 #      orac_print "$frmdate $pubdate\n";
               _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBDAT VALUE=$pubdate COMMENT=[UTC]|Date|the|frame|becomes|public
 
-              _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE='OPERATIONAL'
+              my $engstate = 'OPERATIONAL';
+              _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE=$engstate
 
 # Set recipe used
               my $recipe = $Frm->recipe;

--- a/src/primitives/imaging/LCOSINISTRO/_DERIVED_PRODUCTS_
+++ b/src/primitives/imaging/LCOSINISTRO/_DERIVED_PRODUCTS_
@@ -340,14 +340,11 @@ use ORAC::Version;
       _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBDAT VALUE=$pubdate COMMENT=[UTC]|Date|the|frame|becomes|public
 
       my $siteid = $Frm->hdr( "SITEID");
-
       if ( $siteid ne "bpl" ) {
-        orac_print "SiteID=$siteid, setting to OPERATIONAL\n";
-        _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE='OPERATIONAL'
-      } else {
-        orac_print "SiteID=$siteid, setting to COMMISSIONING\n";
-        _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE='COMMISSIONING'
+        $engstate = 'OPERATIONAL';
       }
+      orac_print "SiteID=$siteid, setting to $engstate\n";
+      _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE=$engstate
 
 
 # Set recipes used

--- a/src/primitives/imaging/LCOSINISTRO/_MAKE_BIAS_FROM_GROUP_
+++ b/src/primitives/imaging/LCOSINISTRO/_MAKE_BIAS_FROM_GROUP_
@@ -249,13 +249,15 @@ use File::Copy;
           _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1QIMGST VALUE=$img_status, COMMENT=Image|taking|status|(bitmask;-1=Unknown,0=OK)
 
 # Set public/private flag and release date
-          _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBPRV VALUE='public' COMMENT=Public|or|private|data?
+          my $pubpriv = 'public';
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBPRV VALUE=$pubpriv COMMENT=Public|or|private|data?
 
           my $pubdate =  $Frm->hdr( "ORACDATETIME");
 #      orac_print "$pubdate\n";
           _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBDAT VALUE=$pubdate COMMENT=[UTC]|Date|the|frame|becomes|public
 
-          _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE='OPERATIONAL'
+          my $engstate = 'OPERATIONAL';
+          _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE=$engstate
 
 # Set recipe used
           my $recipe = $Frm->recipe;

--- a/src/primitives/imaging/LCOSINISTRO/_MAKE_DARK_FROM_GROUP_
+++ b/src/primitives/imaging/LCOSINISTRO/_MAKE_DARK_FROM_GROUP_
@@ -42,7 +42,7 @@
 #    TAL: Tim Lister (LCOGT)
 #
 # Copyright:
-#    Copyright (C) 2012 Las Cumbres Observatory Global Telescope Inc.
+#    Copyright (C) 2012, 2015 Las Cumbres Observatory Global Telescope Inc.
 #    All Rights Reserved.
 #
 #-
@@ -271,13 +271,15 @@ use File::Copy;
             _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1QIMGST VALUE=$img_status, COMMENT=Image|taking|status|(bitmask;-1=Unknown,0=OK)
 
 # Set public/private flag and release date
-            _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBPRV VALUE='public' COMMENT=Public|or|private|data?
+            my $pubpriv = 'public';
+            _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBPRV VALUE=$pubpriv COMMENT=Public|or|private|data?
 
             my $pubdate =  $Frm->hdr( "ORACDATETIME");
 #      orac_print "$pubdate\n";
             _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBDAT VALUE=$pubdate COMMENT=[UTC]|Date|the|frame|becomes|public
 
-            _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE='OPERATIONAL'
+            my $engstate = 'OPERATIONAL';
+            _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE=$engstate
 
 # Set recipe used
             my $recipe = $Frm->recipe;
@@ -386,7 +388,7 @@ Tim Lister (tlister@lcogt.net)
 
 =head1 COPYRIGHT
 
-Copyright (C) 2012 Las Cumbres Observatory Global Telescope Inc.
+Copyright (C) 2012, 2015 Las Cumbres Observatory Global Telescope Inc.
 All Rights Reserved.
 
 =cut

--- a/src/primitives/imaging/LCOSINISTRO/_MAKE_FLAT_FROM_GROUP_
+++ b/src/primitives/imaging/LCOSINISTRO/_MAKE_FLAT_FROM_GROUP_
@@ -400,13 +400,15 @@ use File::Copy;
               _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1QIMGST VALUE=$img_status, COMMENT=Image|taking|status|(bitmask;-1=Unknown,0=OK)
 
 # Set public/private flag and release date
-              _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBPRV VALUE='public' COMMENT=Public|or|private|data?
+              my $pubpriv = 'public';
+              _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBPRV VALUE=$pubpriv COMMENT=Public|or|private|data?
 
               my $pubdate =  $Frm->hdr( "ORACDATETIME");
 #      orac_print "$frmdate $pubdate\n";
               _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBDAT VALUE=$pubdate COMMENT=[UTC]|Date|the|frame|becomes|public
 
-              _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE='OPERATIONAL'
+              my $engstate = 'OPERATIONAL';
+              _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE=$engstate
 
 # Set recipe used
               my $recipe = $Frm->recipe;

--- a/src/primitives/imaging/LCOSPECTRAL/_MAKE_BIAS_FROM_GROUP_
+++ b/src/primitives/imaging/LCOSPECTRAL/_MAKE_BIAS_FROM_GROUP_
@@ -44,7 +44,7 @@
 #    TAL: Tim Lister (LCOGT)
 #
 # Copyright:
-#    Copyright (C) 2012-2014 Las Cumbres Observatory Global Telescope Inc.
+#    Copyright (C) 2012-2015 Las Cumbres Observatory Global Telescope Inc.
 #    All Rights Reserved.
 #
 #-
@@ -275,13 +275,15 @@ use File::Copy;
 	    _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1QIMGST VALUE=$img_status, COMMENT=Image|taking|status|(bitmask;-1=Unknown,0=OK)
 
 # Set public/private flag and release date
-	    _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBPRV VALUE='public' COMMENT=Public|or|private|data?
+            my $pubpriv = 'public';
+	    _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBPRV VALUE=$pubpriv COMMENT=Public|or|private|data?
 
 	    my $pubdate =  $Frm->hdr( "ORACDATETIME");
 #      orac_print "$pubdate\n";
 	    _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBDAT VALUE=$pubdate COMMENT=[UTC]|Date|the|frame|becomes|public
 
-	    _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE='OPERATIONAL'
+            my $engstate = 'OPERATIONAL';
+	    _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE=$engstate
 
 # Set recipe used
       	    my $recipe = $Frm->recipe;
@@ -394,7 +396,7 @@ Tim Lister (tlister@lcogt.net)
 
 =head1 COPYRIGHT
 
-Copyright (C) 2012-2014 Las Cumbres Observatory Global Telescope Inc.
+Copyright (C) 2012-2015 Las Cumbres Observatory Global Telescope Inc.
 All Rights Reserved.
 
 =cut

--- a/src/primitives/imaging/LCOSPECTRAL/_MAKE_FLAT_FROM_GROUP_
+++ b/src/primitives/imaging/LCOSPECTRAL/_MAKE_FLAT_FROM_GROUP_
@@ -348,13 +348,15 @@ use File::Copy;
               _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1QIMGST VALUE=$img_status, COMMENT=Image|taking|status|(bitmask;-1=Unknown,0=OK)
 
 # Set public/private flag and release date
-              _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBPRV VALUE='public' COMMENT=Public|or|private|data?
+              my $pubpriv = 'public';
+              _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBPRV VALUE=$pubpriv COMMENT=Public|or|private|data?
 
               my $pubdate =  $Frm->hdr( "ORACDATETIME");
 #      orac_print "$frmdate $pubdate\n";
               _SET_FILE_FITS_ITEM_ FILE=$file KEY=L1PUBDAT VALUE=$pubdate COMMENT=[UTC]|Date|the|frame|becomes|public
 
-              _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE='OPERATIONAL'
+              my $engstate = 'OPERATIONAL';
+              _SET_FILE_FITS_ITEM_ FILE=$file KEY=ENGSTATE VALUE=$engstate
 
 # Set recipe used
               my $recipe = $Frm->recipe;


### PR DESCRIPTION
Fix for wrong use of string literals with _SET_FILE_FITS_ITEM_ and missing terminator on PODule. Would be great if these made it into 2015A.
Thanks,
TimL