### PR TITLE
Reference grid

### DIFF
--- a/src/primitives/heterodyne/_COMPARE_SPECIES_
+++ b/src/primitives/heterodyne/_COMPARE_SPECIES_
@@ -1,0 +1,149 @@
+=head1 NAME
+
+_COMPARE_SPECIES_
+
+=head1 DESCRIPTION
+
+This primitive compares the molecular species, i.e. the molecule and
+transitions of the current Frame or Group (see Argument OBJ) against a
+reference dataset (Argument REF).  Depending on the setting of
+Argument ABORT, a mismatch will either abort the reduction, or merely
+issue a warning listing the differences.
+
+=head1 ARGUMENTS
+
+=over 4
+
+=item ABORT = BOOOLEAN (Given)
+
+If set to 1 (true), the if the species do not match, an error message
+is reported and the recipe aborts. If set to 0 (false), only a warning
+message is reported.  The later caters for cases with missing metadata
+where the two observations are of the same molecule and transition.
+[0]
+
+=item OBJ = ORAC::Frame/ORAC::Group object (Given)
+
+The ORAC::Frame or ORAC::Group object from which the MOLECULE and TRANSITI
+headers are taken.  [current ORAC::Frame object]
+
+=item REF = STRING (Given)
+
+The name of the reference file against which to compare the species.  This 
+should currently be an NDF of an ACSIS observation.  An error will occur if
+no name is supplied.
+
+=back
+
+=head1 NOTES
+
+=over 4
+
+It converts the molecule and transition to the form <molecule(<transition>)
+with all whitespace removed.  If there is a mismatch, the message reports the
+two species in this form.
+
+=over 4
+
+=head 1 TASKS
+
+None.
+
+=head1 REQUIRED PERL MODULES
+
+None.
+
+=head1 AUTHORS
+
+Malcolm J. Currie E<lt>mjc@star.rl.ac.ukE<gt>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2019 Science and Technology Facilities Council.
+All Rights Reserved.
+
+=head1 LICENCE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either Version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public
+License along with this program; if not, write to the Free
+Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+MA 02111-1307, USA.
+
+=cut
+
+# Preliminaries
+# =============
+
+# Handle arguments.
+my $abort = get_prim_arg( $_PRIM_ARGS_, "ABORT", 0 );
+my $Obj = get_prim_arg( $_PRIM_ARGS_, "OBJ", $Frm );
+my $ref = get_prim_arg( $_PRIM_ARGS_, "REF", "undef" );
+
+if ( ! defined( $ref ) ) {
+   orac_err "_COMPARE_SPECIES_: Programming error.  A reference " .
+            "file must be supplied via Argument REF.\n";
+}
+
+# Obtain the headers from the reference data file.
+my $refFrm = new $Frm;
+$refFrm->file( $ref );
+$refFrm->readhdr();
+
+# Compare the molecules and transitions
+# =====================================
+
+# The comparison is between the current Frame or Group filoe and the
+# reference file, to advise whether or not a combination of the two
+# makes sense.
+
+# Convert the current Group or Frame object's molecule and transition
+# to a standard form removing whitespace.
+my $molecule = "";
+my $transition = "";
+if ( defined( $Obj->hdr( "MOLECULE" ) ) ) {
+   $molecule = $Obj->hdr( "MOLECULE" );
+   $molecule =~ s/\s//g;
+   if ( defined( $Obj->hdr( "TRANSITI" ) ) ) {
+      $transition .=  $Obj->hdr( "TRANSITI" );
+      $transition =~ s/\s//g;
+   }
+}
+
+# Convert the reference data file's molecule and tranisiion to a
+# standard form removing whitespace.
+my $molecule_ref = "";
+my $transition_ref = "";
+if ( defined( $refFrm->hdr( "MOLECULE" ) ) ) {
+   $molecule_ref = $refFrm->hdr( "MOLECULE" );
+   $molecule_ref =~ s/\s//g;
+   if ( defined( $refFrm->hdr( "TRANSITI" ) ) ) {
+      $transition_ref .= $refFrm->hdr( "TRANSITI" );
+      $transition_ref =~ s/\s//g;
+   }
+}
+
+# Create the standard formats, and finally perform the comparison.
+my $moletran = $molecule . "(" . $transition . ")";
+my $moletran_ref = $molecule_ref . "(" . $transition_ref . ")";
+if ( $moletran ne $moletran_ref ) {
+   if ( $abort ) {
+      orac_err "The molecule and/or transition of the current " .
+               "observation ($moletran) do not match that of the " .
+               "reference data ($moletran_ref).\n";
+   } else {
+      orac_warn "The molecule and/or transition of the current " .
+                "observation ($moletran) do not match that of the " .
+                "reference data ($moletran_ref).\n";
+   }
+}
+

--- a/src/primitives/heterodyne/_COMPARE_SPECIES_
+++ b/src/primitives/heterodyne/_COMPARE_SPECIES_
@@ -5,10 +5,11 @@ _COMPARE_SPECIES_
 =head1 DESCRIPTION
 
 This primitive compares the molecular species, i.e. the molecule and
-transitions of the current Frame or Group (see Argument OBJ) against a
-reference dataset (Argument REF).  Depending on the setting of
-Argument ABORT, a mismatch will either abort the reduction, or merely
-issue a warning listing the differences.
+transition (as given by internal headers ORAC_SPECIES and
+ORAC_TRANSITION) of the current Frame or Group (see Argument GROUP)
+against a reference dataset (Argument REF).  Depending on the setting
+of Argument ABORT, a mismatch will either abort the reduction, or
+merely issue a warning listing the differences.
 
 =head1 ARGUMENTS
 
@@ -102,7 +103,7 @@ $refFrm->readhdr();
 # Compare the molecules and transitions
 # =====================================
 
-# The comparison is between the current Frame or Group filoe and the
+# The comparison is between the current Frame or Group file and the
 # reference file, to advise whether or not a combination of the two
 # makes sense.
 
@@ -110,24 +111,24 @@ $refFrm->readhdr();
 # to a standard form removing whitespace.
 my $molecule = "";
 my $transition = "";
-if ( defined( $Obj->hdr( "MOLECULE" ) ) ) {
-   $molecule = $Obj->hdr( "MOLECULE" );
+if ( defined( $Obj->uhdr( "ORAC_SPECIES" ) ) ) {
+   $molecule = $Obj->uhdr( "ORAC_SPECIES" );
    $molecule =~ s/\s//g;
-   if ( defined( $Obj->hdr( "TRANSITI" ) ) ) {
-      $transition .=  $Obj->hdr( "TRANSITI" );
+   if ( defined( $Obj->uhdr( "ORAC_TRANSITION" ) ) ) {
+      $transition .=  $Obj->uhdr( "ORAC_TRANSITION" );
       $transition =~ s/\s//g;
    }
 }
 
-# Convert the reference data file's molecule and tranisiion to a
+# Convert the reference data file's molecule and transition to a
 # standard form removing whitespace.
 my $molecule_ref = "";
 my $transition_ref = "";
-if ( defined( $refFrm->hdr( "MOLECULE" ) ) ) {
-   $molecule_ref = $refFrm->hdr( "MOLECULE" );
+if ( defined( $refFrm->uhdr( "ORAC_SPECIES" ) ) ) {
+   $molecule_ref = $refFrm->uhdr( "ORAC_SPECIES" );
    $molecule_ref =~ s/\s//g;
-   if ( defined( $refFrm->hdr( "TRANSITI" ) ) ) {
-      $transition_ref .= $refFrm->hdr( "TRANSITI" );
+   if ( defined( $refFrm->uhdr( "ORAC_TRANSITION" ) ) ) {
+      $transition_ref .= $refFrm->uhdr( "ORAC_TRANSITION" );
       $transition_ref =~ s/\s//g;
    }
 }

--- a/src/primitives/heterodyne/_COMPARE_SPECIES_
+++ b/src/primitives/heterodyne/_COMPARE_SPECIES_
@@ -23,14 +23,15 @@ message is reported.  The later caters for cases with missing metadata
 where the two observations are of the same molecule and transition.
 [0]
 
-=item OBJ = ORAC::Frame/ORAC::Group object (Given)
+item GROUP = BOOLEAN (Given)
 
-The ORAC::Frame or ORAC::Group object from which the MOLECULE and TRANSITI
-headers are taken.  [current ORAC::Frame object]
+If true, use the Group object to compare against the reference object.
+If false, the current Frame object is selected for the comparison.
+Whether or not to use the Group object to collapse over. [0]
 
 =item REF = STRING (Given)
 
-The name of the reference file against which to compare the species.  This 
+The name of the reference file against which to compare the species.  This
 should currently be an NDF of an ACSIS observation.  An error will occur if
 no name is supplied.
 
@@ -87,12 +88,20 @@ MA 02111-1307, USA.
 
 # Handle arguments.
 my $abort = get_prim_arg( $_PRIM_ARGS_, "ABORT", 0 );
-my $Obj = get_prim_arg( $_PRIM_ARGS_, "OBJ", $Frm );
+my $group = get_prim_arg( $_PRIM_ARGS_, "GROUP", 0 );
 my $ref = get_prim_arg( $_PRIM_ARGS_, "REF", "undef" );
 
 if ( ! defined( $ref ) ) {
    orac_err "_COMPARE_SPECIES_: Programming error.  A reference " .
             "file must be supplied via Argument REF.\n";
+}
+
+# Assign the object to be compared,.
+my $Obj;
+if( $group ) {
+   $Obj = $Grp;
+} else {
+   $Obj = $Frm;
 }
 
 # Obtain the headers from the reference data file.

--- a/src/primitives/heterodyne/_CREATE_CUBE_FRAME_
+++ b/src/primitives/heterodyne/_CREATE_CUBE_FRAME_
@@ -360,9 +360,10 @@ my $badmask = $mc_hash->{badmask};
 my $alignsys = $mc_hash->{alignsys};
 my $ORAC_STATUS;
 
-if( $type ne "raster" ) {
 # Determine the grid from the reference file.
 # -------------------------------------------
+if ( $useref ) {
+  orac_say "Aligning the output spectral cube to $refppv.";
 
   # Check that the current Frame and the reference file are observations
   # of the same molecule and transition.  Only issue a warning if there
@@ -441,11 +442,8 @@ if( $type ne "raster" ) {
     $params .= " autogrid";
   }
 
-foreach my $mc_param ( qw/ detectors usedetpos badmask alignsys / ) {
-  if( defined( $mc_hash->{$mc_param} ) ) {
-    $params .= " $mc_param=" . $mc_hash->{$mc_param};
-  }
-}
+# Obtain the reference pixel and assign its MAKECUBE parameters.
+# --------------------------------------------------------------
 
 # Record the reference pixel for the first call to this primitive for
 # the current Frm.  If data are excluded by masking the ends of the

--- a/src/primitives/heterodyne/_CREATE_CUBE_FRAME_
+++ b/src/primitives/heterodyne/_CREATE_CUBE_FRAME_
@@ -355,7 +355,7 @@ if( $type ne "raster" ) {
   # Check that the current Frame and the reference file are observations
   # of the same molecule and transition.  Only issue a warning if there
   # is a mismatch.
-  _COMPARE_SPECIES_ OBJ=$Frm REF=$refppv ABORT=0
+  _COMPARE_SPECIES_ GROUP=0 REF=$refppv ABORT=0
   
 # Specify the reference cube.
   $params = "ref=$refppv";

--- a/src/primitives/heterodyne/_CREATE_CUBE_FRAME_
+++ b/src/primitives/heterodyne/_CREATE_CUBE_FRAME_
@@ -221,6 +221,9 @@ MA 02111-1307, USA.
 
 =cut
 
+# Definitions
+# ===========
+
 use ORAC::Constants qw/ :badvalues /;
 use Starlink::HDSPACK qw/ create_hdsobj copy_hdsobj /;
 
@@ -236,6 +239,8 @@ use constant MEGABYTE => 1048576;
 use constant JSACHUNK => 1000;
 
 # Deal with parameters.
+# =====================
+
 my $bytes_per_pixel = get_prim_arg( $_PRIM_ARGS_, "BYTES_PER_PIXEL", 4 );
 my $maxsize = get_prim_arg( $_PRIM_ARGS_, "MAXSIZE", 512 );
 my $spread = uc( get_prim_arg( $_PRIM_ARGS_, "SPREAD", 'nearest' ) );
@@ -298,14 +303,15 @@ $chunksize = JSACHUNK if $jsatile;
 # as MAKECUBE deals with smoothing border internally.
 my $tileborder = 0;
 
-my @files;
+# Main processing begins here.
+# ============================
 
 # Create a list of input images.
-
 my $out = $Frm->inout( $suffix );
 
 $Frm->uhdr( "JSA_TILES", 1 ) if $jsatile;
 
+my @files;
 foreach my $i ( 1..$Frm->nfiles ) {
   my $in = $Frm->file( $i );
   push @files, $in;
@@ -316,6 +322,10 @@ my $inlist = write_file_list ( @files );
 # Fix the output filename to remove the subscan number.
 $out =~ s/_\d{4}_/_/;
 
+# Create the command-line parameters for MAKECUBE.
+# ================================================
+
+# This MAKECUBE command line will be assembled in this string.
 my $params = '';
 
 # Is there a reference cube to define the WCS, and is it permitted?
@@ -351,6 +361,8 @@ my $alignsys = $mc_hash->{alignsys};
 my $ORAC_STATUS;
 
 if( $type ne "raster" ) {
+# Determine the grid from the reference file.
+# -------------------------------------------
 
   # Check that the current Frame and the reference file are observations
   # of the same molecule and transition.  Only issue a warning if there
@@ -453,6 +465,9 @@ foreach my $mc_param ( qw/ detectors usedetpos badmask alignsys / ) {
   }
 }
 
+# Append other MAKECUBE parameters to the command line.
+# -----------------------------------------------------
+
 # Figure out the spread parameters.
 _GET_SPREAD_PARAMS_ PARAM1=$param1 PARAM2=$param2 METHOD=$spread PIXSIZE=$pixsize
 my $sp_params = $_GET_SPREAD_PARAMS_{PARAMSTRING};
@@ -483,6 +498,9 @@ if ( $Frm->uhdr("ISHYBRID") ) {
   # badmask.
   $params .= " badmask=AND specunion";
 }
+
+# Append variance generation and weighting parameters.
+# ----------------------------------------------------
 
 # Check the Tsys values. If the mean is negative, then create the
 # variance from the spread of input pixels. Otherwise, test the
@@ -516,6 +534,9 @@ if( ! $Frm->uhdr( "SPARSE" ) ) {
   $Grp->uhdr( "MAKECUBE_PARAMETERS", $params );
 }
 
+# Form list of input filenames.
+# ----------------------------
+
 # Form a list of all the input filenames and determine their total size in
 # megabytes.  Also store the filenames in a GRP list text file.
 my @infiles;
@@ -536,7 +557,8 @@ if ( $chunk ) {
   $mean_chunksize = $totalsize / $num_chunk;
 }
 
-#-------------------------------------------------------------------
+# Extract reference co-ordinates and bounds.
+#-------------------------------------------
 
 # Do not create the output file, thus this is a quick operation.
 $Mon{'smurf_mon'}->obeyw( "makecube", "$params in='^$inlist' out=!" );
@@ -576,7 +598,8 @@ $params =~ s/autogrid /autogrid=n / if ( $totalsize > $chunksize && $chunk );
 # Obtain the total number of tiles.
 ( $ORAC_STATUS, my $totaltile ) = $Mon{'smurf_mon'}->get( "makecube", "ntile" );
 
-#-----------------------------------------------------------------
+# Make the spectral cubes.
+# ========================
 
 my @jsatilelist;
 my $makecube_outfile;
@@ -598,6 +621,9 @@ if ( $totalsize <= $chunksize || !$chunk || $num_chunk < 2 ) {
     ( $ORAC_STATUS, $totaltile ) = $Mon{'smurf_mon'}->get( "makecube", "ntile" );
     orac_say "Total number of HPX tiles spanned is $totaltile";
   }
+
+  # Create a VARIANCE component, if absent.
+  # =======================================
 
   # See if MAKECUBE created a VARIANCE component.  CADC demands that one be
   # present in reduced products.  Create one if variance is absent and fill
@@ -659,6 +685,9 @@ if ( $totalsize <= $chunksize || !$chunk || $num_chunk < 2 ) {
     }
   }
 
+# Chunking
+# ========
+
 # Divide and conquer.  For JSA tiles the chunks are numbered by their
 # HPX tile indices.
 } else {
@@ -671,6 +700,9 @@ if ( $totalsize <= $chunksize || !$chunk || $num_chunk < 2 ) {
     orac_say "Total number of chunked tiles to reassemble is $totaltile";
   }
 }
+
+# Rename the output cubes.
+# ========================
 
 if ( $totaltile > 1 || $jsatile ) {
 
@@ -696,6 +728,9 @@ if ( $totaltile > 1 || $jsatile ) {
        $makecube_outfile = "${out}_$j" . ".sdf";
        $outfile = "${out}" . sprintf( "%03d", $outfilenumber ) . ".sdf";
     }
+
+    # Report processing statistics.
+    # =============================
 
     if ( -e $makecube_outfile ) {
 
@@ -732,6 +767,9 @@ if ( $totaltile > 1 || $jsatile ) {
   # The HEALPix TILENUM headers written by MAKECUBE should be known to ORAC-DR.
   $Frm->readhdr() if $jsatile;
 
+# Rename for a single spectral cube.
+# ==================================
+
 } elsif ( $totaltile == 1 ) {
 
   # We want the output file to be named _cube001.
@@ -748,6 +786,9 @@ if ( $totaltile > 1 || $jsatile ) {
   orac_throw " No cube product formed.  Aborting.\n";
 }
 
+# Tagging
+# =======
+
 # Set the product.
 $Frm->product( $product );
 $Frm->sync_headers;
@@ -758,6 +799,8 @@ if( $tag ) {
 }
 
 # Retrieve and set the Group REFLAT/REFLON if they're not already set.
+# ====================================================================
+
 if( ! defined( $Grp->uhdr( "REFLAT" ) ) ) {
   my $ndf = $Frm->file( 1 );
 
@@ -789,6 +832,8 @@ if( ! defined( $Grp->uhdr( "REFLAT" ) ) ) {
   $Grp->uhdr( "REFLON", $reflon );
 
 }
+
+# --------------------------------------------------------------------
 
 # Set a tag on this one so we can retrieve it later if necessary.
 _SET_TAG_ TAG=POST_CREATE_CUBE_FRAME

--- a/src/primitives/heterodyne/_CREATE_CUBE_FRAME_
+++ b/src/primitives/heterodyne/_CREATE_CUBE_FRAME_
@@ -352,83 +352,82 @@ my $ORAC_STATUS;
 
 if( $type ne "raster" ) {
 
-  my $inlist2 = write_file_list( $Frm->files );
-
-  orac_print "Determining parameters for output cube...";
-  $Mon{'smurf_mon'}->obeyw( "makecube", "$mc_params in='^$inlist2' out=!" );
-  orac_print "done.\n";
-
-  # Check to see if we have a sparse cube.
-  $Frm->uhdr( "SPARSE", 0 );
-  ( $ORAC_STATUS, my $sparse ) = $Mon{'smurf_mon'}->get( "makecube", "sparse" );
-  if( uc( $sparse ) eq 'TRUE' ) {
-    orac_warn "Resulting cube will be sparse.\n";
-    $Frm->uhdr( "SPARSE", 1 );
-  } else {
-
-    # Get the returned pixsize and crota.
-    ( $ORAC_STATUS, $ppixsize ) = $Mon{'smurf_mon'}->get( "makecube", "pixsize" );
-    ( $ORAC_STATUS, $crota ) = $Mon{'smurf_mon'}->get( "makecube", "crota" );
-
-    # Check the pixel size. If it's smaller than a quarter of the
-    # beamsize, set it to a quarter of the beamsize, unless it's a
-    # pointing.
-    if( $type ne 'pointing' ) {
-      my $lofreqs = defined( $Frm->hdr( "LOFREQS" ) ) ?
-                    $Frm->hdr( "LOFREQS" )            :
-                    $Frm->jcmtstate( "FE_LOFREQ" );
-
-      my $min_pixsize = int( FREQ2PIXSIZE / $lofreqs + 0.5 );
-      if ( $ppixsize < $min_pixsize ) {
-        orac_warn "Default pixel size enlarged to the minimum pixel (quarter beam size).\n";
-        $ppixsize = $min_pixsize;
-      }
-    }
-  }
-
-} else {
-  $ppixsize = $mc_hash->{pixsize};
-  $crota = $mc_hash->{crota};
-}
-
-# Override the system and crota if the system has been passed in as an
-# argument.
-if( defined( $system_arg ) ) {
-  $system = $system_arg;
-  $crota = 0;
-}
-
-# If we haven't been given an override pixel scale, use the one we
-# just determined.
-if( ! defined( $pixsize ) ) {
-  $pixsize = $ppixsize;
-}
-
-# Figure out the spread parameters.
-_GET_SPREAD_PARAMS_ PARAM1=$param1 PARAM2=$param2 METHOD=$spread PIXSIZE=$pixsize
-my $sp_params = $_GET_SPREAD_PARAMS_{PARAMSTRING};
-
-# Is there a reference cube to define the WCS, and is it permitted?
-my $useref = defined $refppv && -e $refppv && ! $Frm->uhdr( "ISHYBRID" );
-if ( $useref ) {
-  orac_say "Aligning the output spectral cube to $refppv.";
-
   # Check that the current Frame and the reference file are observations
-  # of the same molecule and transition.
+  # of the same molecule and transition.  Only issue a warning if there
+  # is a mismatch.
   _COMPARE_SPECIES_ OBJ=$Frm REF=$refppv ABORT=0
+  
+# Specify the reference cube.
+  $params = "ref=$refppv";
 
-  # Must not be 'AND' lest we not find any overlap with the reference
-  # cube.
+  # BADMASK must not be 'AND' lest we not find any overlap with the
+  # reference ube.
   $mc_hash->{badmask} = 'OR';
 
 } else {
-  if ( ! $Frm->uhdr( "SPARSE" ) ) {
-    $params = "pixsize=$pixsize crota=$crota autogrid=$autogrid";
+
+# Obtain the pixel scale and rotation angle.
+# ------------------------------------------
+  if ( $type ne "raster" ) {
+
+    my $inlist2 = write_file_list( $Frm->files );
+
+    orac_print "Determining parameters for output cube...";
+    $Mon{'smurf_mon'}->obeyw( "makecube", "$mc_params in='^$inlist2' out=!" );
+    orac_print "done.\n";
+
+    # Check to see if we have a sparse cube.
+    $Frm->uhdr( "SPARSE", 0 );
+    ( $ORAC_STATUS, my $sparse ) = $Mon{'smurf_mon'}->get( "makecube", "sparse" );
+    if ( uc( $sparse ) eq 'TRUE' ) {
+      orac_warn "Resulting cube will be sparse.\n";
+      $Frm->uhdr( "SPARSE", 1 );
+    } else {
+
+      # Get the returned pixsize and crota.
+      ( $ORAC_STATUS, $ppixsize ) = $Mon{'smurf_mon'}->get( "makecube", "pixsize" );
+      ( $ORAC_STATUS, $crota ) = $Mon{'smurf_mon'}->get( "makecube", "crota" );
+
+      # Check the pixel size. If it's smaller than a quarter of the
+      # beamsize, set it to a quarter of the beamsize, unless it's a
+      # pointing.
+      if ( $type ne 'pointing' ) {
+        my $lofreqs = defined( $Frm->hdr( "LOFREQS" ) ) ?
+                      $Frm->hdr( "LOFREQS" )            :
+                      $Frm->jcmtstate( "FE_LOFREQ" );
+
+        my $min_pixsize = int( FREQ2PIXSIZE / $lofreqs + 0.5 );
+        if ( $ppixsize < $min_pixsize ) {
+          orac_warn "Default pixel size enlarged to the minimum pixel (quarter beam size).\n";
+          $ppixsize = $min_pixsize;
+        }
+      }
+    }
+
   } else {
-    $params = "autogrid";
+    $ppixsize = $mc_hash->{pixsize};
+    $crota = $mc_hash->{crota};
   }
-}
-$params .= " system=$system spread=$spread params=$sp_params";
+
+  # Override the system and crota if the system has been passed in as an
+  # argument.
+  if ( defined( $system_arg ) ) {
+    $system = $system_arg;
+    $crota = 0;
+  }
+
+  # If we haven't been given an override pixel scale, use the one we
+  # just determined.
+  if ( ! defined( $pixsize ) ) {
+    $pixsize = $ppixsize;
+  }
+
+  $params = "system=$system";
+  if ( ! $Frm->uhdr( "SPARSE" ) ) {
+    $params .= " pixsize=$pixsize crota=$crota autogrid=$autogrid";
+  } else {
+    $params .= " autogrid";
+  }
 
 foreach my $mc_param ( qw/ detectors usedetpos badmask alignsys / ) {
   if( defined( $mc_hash->{$mc_param} ) ) {
@@ -441,7 +440,6 @@ foreach my $mc_param ( qw/ detectors usedetpos badmask alignsys / ) {
 # spectrum for example, the autogrid centring can change by a spatial
 # pixel.  This is catastrophic for a single spectrum cube as the masked
 # and unmasked data have non-overlapping bounds.
-if ( ! $useref ) {
   my @refpix;
   if ( $Frm->uhdr( "SPARSE" ) || $autogrid eq 'yes' && $type ne "raster" ) {
     if ( ! defined $Frm->uhdr( "REFPIX1" ) ) {
@@ -452,6 +450,18 @@ if ( ! $useref ) {
       @refpix = ( $Frm->uhdr( "REFPIX1" ), $Frm->uhdr( "REFPIX2" ) );
       $params .= " refpix1=$refpix[0] refpix2=$refpix[1]";
     }
+  }
+}
+
+# Figure out the spread parameters.
+_GET_SPREAD_PARAMS_ PARAM1=$param1 PARAM2=$param2 METHOD=$spread PIXSIZE=$pixsize
+my $sp_params = $_GET_SPREAD_PARAMS_{PARAMSTRING};
+
+$params .= " spread=$spread params=$sp_params";
+
+foreach my $mc_param ( qw/ detectors usedetpos badmask alignsys / ) {
+  if ( defined( $mc_hash->{$mc_param} ) ) {
+    $params .= " $mc_param=" . $mc_hash->{$mc_param};
   }
 }
 
@@ -487,6 +497,7 @@ $Mon{'kappa_mon'}->obeyw( "stats", "ndf=$tmptsys" );
 if( $tsysmean < 0 && $tsysmean != VAL__BADD ) {
   orac_warn "Mean Tsys negative ($tsysmean). Using spread of input pixels for variance creation.\n";
   $params .= " genvar=spread noinweight";
+
 } else {
   $Mon{'ndfpack_mon'}->obeyw( "ndftrace", "ndf=$files[0]" );
   ( $ORAC_STATUS, my $units ) = $Mon{'ndfpack_mon'}->get( "ndftrace", "units" );
@@ -496,9 +507,6 @@ if( $tsysmean < 0 && $tsysmean != VAL__BADD ) {
     $params .= " genvar=spread inweight=false";
   }
 }
-
-# Specify the reference cube.
-$params .= " ref=$refppv" if $useref;
 
 $params .= " jsatiles" if $jsatile;
 
@@ -526,7 +534,6 @@ my ( $num_chunk, $mean_chunksize );
 if ( $chunk ) {
   $num_chunk = int( $totalsize / $chunksize ) + 1;
   $mean_chunksize = $totalsize / $num_chunk;
-
 }
 
 #-------------------------------------------------------------------

--- a/src/primitives/heterodyne/_CREATE_CUBE_FRAME_
+++ b/src/primitives/heterodyne/_CREATE_CUBE_FRAME_
@@ -318,8 +318,24 @@ $out =~ s/_\d{4}_/_/;
 
 my $params = '';
 
-# Determine the MAKECUBE parameters based on the
-# ORAC_OBSERVATION_TYPE header.
+# Is there a reference cube to define the WCS, and is it permitted?
+# Cope with the NDF file extension being present or not.
+my $useref = 0;
+if ( defined $refppv ) {
+  $refppv .= ".sdf" if $refppv !~ /sdf$/;
+  if ( -e $refppv ) {
+    $useref = 1;
+  } else {
+    orac_warn "Reference file $refppv does not exist.  Continuing to " .
+              "process without reference grid.\n";
+  }
+  if ( $Frm->uhdr( "ISHYBRID" ) ) {
+    $useref = 0;
+    orac_warn "Cannot currently use a reference file for hybrid data.\n";
+  }
+}
+
+# Determine the MAKECUBE parameters based on the observation type.
 my $type = lc( $Frm->uhdr( "ORAC_OBSERVATION_TYPE" ) );
 
 _GET_MAKECUBE_PARAMS_ TYPE=$type

--- a/src/primitives/heterodyne/_CREATE_CUBE_FRAME_
+++ b/src/primitives/heterodyne/_CREATE_CUBE_FRAME_
@@ -85,6 +85,20 @@ RECPAR_PIXSIZE uhdr via the recipe parameter system. []
 
 Override the default "cube" product designation.
 
+=item REFERENCE = STRING (Given)
+
+The name of an NDF spectral cube that defines the grid on to which the
+output group spectral cube will be aligned.  This rarely used option
+permits observations taken with different spectral and/or spatial
+resolutions to be combined later.  The reference cube is normally one
+with wider spectral channels.  This facility does not operate if the
+reference NDF is undefined or the NDF does not exist or if the
+observation is hybrid.  A warning is issued if the current group data
+and the reference NDF do not have matching molecules and transitions.
+
+This argument can be overridden by the RECPAR_REFERENCE_PPV uhdr via
+the recipe parameter system.  [undef]
+
 =item SPREAD = STRING (Given)
 
 The interpolation method to use when regridding the cube. This can be
@@ -179,12 +193,12 @@ None.
 
 =head1 AUTHORS
 
-Brad Cavanagh <b.cavanagh@jach.hawaii.edu>
-Malcolm J. Currie E<lt>mjc@jach.hawaii.eduE<gt>
+Brad Cavanagh E<lt>b.cavanagh@jach.hawaii.eduE<gt>
+Malcolm J. Currie E<lt>mjc@star.rl.ac.ukE<gt>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2008, 2010, 2012-2015 Science and Technology Facilities Council.
+Copyright (C) 2008, 2010, 2012-2015, 2019 Science and Technology Facilities Council.
 Copyright (C) 2006-2007 Particle Physics and Astronomy Research Council.
 All Rights Reserved.
 
@@ -231,6 +245,7 @@ my $pixsize = get_prim_arg( $_PRIM_ARGS_, "PIXSIZE", undef );
 my $tag = get_prim_arg( $_PRIM_ARGS_, "TAG", 0 );
 my $chunksize = get_prim_arg( $_PRIM_ARGS_, "CHUNKSIZE", 5120 );
 my $jsatile = get_prim_arg( $_PRIM_ARGS_, "JSATILE", 0 );
+my $refppv = get_prim_arg( $_PRIM_ARGS_, "REFERENCE", undef );
 my $tile = get_prim_arg( $_PRIM_ARGS_, "TILE", ! $jsatile );
 my $chunk = get_prim_arg( $_PRIM_ARGS_, "CHUNK", 0 );
 
@@ -260,6 +275,9 @@ if( $override ) {
   $pixsize = ( defined( $Frm->uhdr( "RECPAR_PIXSIZE" ) ) ?
                $Frm->uhdr( "RECPAR_PIXSIZE" )            :
                $pixsize );
+  $refppv = ( defined( $Frm->uhdr( "RECPAR_REFERENCE_PPV" ) ) ?
+              $Frm->uhdr( "RECPAR_REFERENCE_PPV" )            :
+              $refppv );
   $spread = ( defined( $Frm->uhdr( "RECPAR_SPREAD_METHOD" ) ) ?
               $Frm->uhdr( "RECPAR_SPREAD_METHOD" )            :
               $spread );
@@ -374,10 +392,25 @@ if( ! defined( $pixsize ) ) {
 _GET_SPREAD_PARAMS_ PARAM1=$param1 PARAM2=$param2 METHOD=$spread PIXSIZE=$pixsize
 my $sp_params = $_GET_SPREAD_PARAMS_{PARAMSTRING};
 
-if( ! $Frm->uhdr( "SPARSE" ) ) {
-  $params = "pixsize=$pixsize crota=$crota autogrid=$autogrid";
+# Is there a reference cube to define the WCS, and is it permitted?
+my $useref = defined $refppv && -e $refppv && ! $Frm->uhdr( "ISHYBRID" );
+if ( $useref ) {
+  orac_say "Aligning the output spectral cube to $refppv.";
+
+  # Check that the current Frame and the reference file are observations
+  # of the same molecule and transition.
+  _COMPARE_SPECIES_ OBJ=$Frm REF=$refppv ABORT=0
+
+  # Must not be 'AND' lest we not find any overlap with the reference
+  # cube.
+  $mc_hash->{badmask} = 'OR';
+
 } else {
-  $params = "autogrid";
+  if ( ! $Frm->uhdr( "SPARSE" ) ) {
+    $params = "pixsize=$pixsize crota=$crota autogrid=$autogrid";
+  } else {
+    $params = "autogrid";
+  }
 }
 $params .= " system=$system spread=$spread params=$sp_params";
 
@@ -392,16 +425,18 @@ foreach my $mc_param ( qw/ detectors usedetpos badmask alignsys / ) {
 # spectrum for example, the autogrid centring can change by a spatial
 # pixel.  This is catastrophic for a single spectrum cube as the masked
 # and unmasked data have non-overlapping bounds.
-my @refpix;
-if ( $Frm->uhdr( "SPARSE" ) || $autogrid eq 'yes' && $type ne "raster" ) {
-   if ( ! defined $Frm->uhdr( "REFPIX1" ) ) {
+if ( ! $useref ) {
+  my @refpix;
+  if ( $Frm->uhdr( "SPARSE" ) || $autogrid eq 'yes' && $type ne "raster" ) {
+    if ( ! defined $Frm->uhdr( "REFPIX1" ) ) {
       ( my $ORAC_STATUS, @refpix ) = $Mon{'smurf_mon'}->get( "makecube", "pixref" );
       $Frm->uhdr( "REFPIX1", $refpix[0] );
       $Frm->uhdr( "REFPIX2", $refpix[1] );
-   } else {
+    } else {
       @refpix = ( $Frm->uhdr( "REFPIX1" ), $Frm->uhdr( "REFPIX2" ) );
       $params .= " refpix1=$refpix[0] refpix2=$refpix[1]";
-   }
+    }
+  }
 }
 
 # Get the tiling dimensions, but only if we're not doing a pointing
@@ -445,6 +480,9 @@ if( $tsysmean < 0 && $tsysmean != VAL__BADD ) {
     $params .= " genvar=spread inweight=false";
   }
 }
+
+# Specify the reference cube.
+$params .= " ref=$refppv" if $useref;
 
 $params .= " jsatiles" if $jsatile;
 
@@ -498,7 +536,8 @@ my $prlb = sprintf( "%.3f", $flbnd[2] );
 my $prub = sprintf( "%.3f", $fubnd[2] );
 
 my $specbounds = "'" . $prlb . "," . $prub . "'";
-$params .= " reflon=$reflon reflat=$reflat specunion specbounds=$specbounds";
+$params .= " reflon=$reflon reflat=$reflat " if ( ! $useref );
+$params .= " specunion specbounds=$specbounds";
 if ( !$jsatile ) {
    $params .= " lbnd=[" . $lbound[0] . "," . $lbound[1] . "]";
    $params .= " ubnd=[" . $ubound[0] . "," . $ubound[1] . "]";
@@ -508,7 +547,7 @@ if ( !$jsatile ) {
 # This is per DSB's advice (20110326) to avoid double counting
 # pixels when chunking and mosaicking.  MAKECUBE sometimes
 # sometimes gives borders one pixel more than would be expected.
-$params .= " refpix1=$prx refpix2=$pry";
+$params .= " refpix1=$prx refpix2=$pry" if ( ! $useref );
 $params =~ s/autogrid /autogrid=n / if ( $totalsize > $chunksize && $chunk );
 
 # Obtain the total number of tiles.

--- a/src/primitives/heterodyne/_CREATE_CUBE_GROUP_
+++ b/src/primitives/heterodyne/_CREATE_CUBE_GROUP_
@@ -321,7 +321,19 @@ if( $Grp->lastallmembers( $Frm ) ) {
 
     # We want to go through each member Frm in the Grp and determine
     # the MAKECUBE parameters individually. Then, we'll take the
-    # smallest pixelscale and use that for the output cube.
+    # smallest pixelscale and use that for the output cube.  An
+    # exception is if a reference file provides the output grid WCS.
+    # whereupon do not need to calculate the WCS through MAKECUBE.
+    my $useref = 0;
+    if ( defined $refppv ) {
+      $refppv .= ".sdf" if $refppv !~ /sdf$/;
+      if ( -e $refppv ) {
+        $useref = 1;
+      } else {
+        orac_warn "Reference file $refppv does not exist.  Continuing to " .
+                  "process without reference grid.\n";
+      }
+    }
 
     my $obstype = $Frm->uhdr( "ORAC_OBSERVATION_TYPE" );
     my %pixsize;

--- a/src/primitives/heterodyne/_CREATE_CUBE_GROUP_
+++ b/src/primitives/heterodyne/_CREATE_CUBE_GROUP_
@@ -539,9 +539,12 @@ if( $Grp->lastallmembers( $Frm ) ) {
     } else {
       $params .= " badmask=and";
 
-    # Quick hack for hybrid-mode observations.
-    if( $Frm->uhdr( "ISHYBRID" ) ) {
-      $params .= " specunion";
+      # Quick hack for hybrid-mode observations.  BADMASK cannot be
+      # "AND" when using a reference file to define the grid, and thus
+      # the default SPECUNION=F will be used.
+      if ( $Frm->uhdr( "ISHYBRID" ) ) {
+        $params .= " specunion";
+      }
     }
 
     # If the data units are Kelvin, then we can generate a variance

--- a/src/primitives/heterodyne/_CREATE_CUBE_GROUP_
+++ b/src/primitives/heterodyne/_CREATE_CUBE_GROUP_
@@ -78,6 +78,20 @@ recipe parameter system.  []
 Whether or not specific arguments can be overridden by the recipe
 parameter system. [1]
 
+=item REFERENCE = STRING (Given)
+
+The name of an NDF spectral cube that defines the grid on to which the
+output group spectral cube will be aligned.  This rarely used option
+permits observations taken with different spectral and/or spatial
+resolutions to be combined later.  The reference cube is normally one
+with wider spectral channels.  This facility does not operate if the
+reference NDF is undefined or the NDF does not exist.  A warning is
+issued if the current group data and the reference NDF do not have
+matching molecules and transitions.
+
+This argument can be overridden by the RECPAR_REFERENCE_PPV uhdr via
+the recipe parameter system.  [undef]
+
 =item SPREAD = STRING (Given)
 
 The interpolation method to use when regridding the cube. This can be
@@ -216,6 +230,7 @@ my $bytes_per_pixel = get_prim_arg( $_PRIM_ARGS_, "BYTES_PER_PIXEL", 4 );
 my $chunksize = get_prim_arg( $_PRIM_ARGS_, "CHUNKSIZE", 5120 );
 my $override = get_prim_arg( $_PRIM_ARGS_, "OVERRIDE", 1 );
 my $jsatile = get_prim_arg( $_PRIM_ARGS_, "JSATILE", 0 );
+my $refppv = get_prim_arg( $_PRIM_ARGS_, "REFERENCE", undef );
 my $tile = get_prim_arg( $_PRIM_ARGS_, "TILE", ! $jsatile );
 
 # Override various parameters via the recipe parameter system.
@@ -235,6 +250,9 @@ if( $override ) {
   $ppixsize = ( defined( $Frm->uhdr( "RECPAR_PIXSIZE" ) ) ?
                 $Frm->uhdr( "RECPAR_PIXSIZE" )            :
                 $ppixsize );
+  $refppv = ( defined( $Frm->uhdr( "RECPAR_REFERENCE_PPV" ) ) ?
+              $Frm->uhdr( "RECPAR_REFERENCE_PPV" )            :
+              $refppv );
   $spread = ( defined( $Frm->uhdr( "RECPAR_SPREAD_METHOD" ) ) ?
               $Frm->uhdr( "RECPAR_SPREAD_METHOD" )            :
               $spread );
@@ -341,6 +359,7 @@ if( $Grp->lastallmembers( $Frm ) ) {
           $crota{$Frm->file(1)} = $crota;
         }
       } else {
+
         # Raster parameters come directly from the
         # _GET_MAKECUBE_PARAMS_ primitive results.
         $pixsize{$Frm->file} = ( defined( $ppixsize ) ? $ppixsize : $mc_hash->{pixsize} );
@@ -367,92 +386,123 @@ if( $Grp->lastallmembers( $Frm ) ) {
     my $usedetpos = ( $#uniq == 0 ? $uniq[0] : 'no' );
     my $tiledims;
     my $sp_params;
+    my $pixsize;
+    my $crota;
 
-    # Check to see if we have any pixel sizes back from the previous
-    # MAKECUBE runs. If we don't have any, then all of the resulting
-    # cubes will be sparse, so set autogrid=yes and ignore
-    # tiling. Otherwise, we want to find the smallest pixel size and
-    # go with that.
-    if ( scalar values %pixsize == 0 ) {
+    # Is there a reference cube to define the WCS?
+    my $useref = defined $refppv && -e $refppv;
 
-      orac_warn "Resulting cube will be sparse.\n";
-      $Grp->uhdr( "SPARSE", 1 );
-      $params = "autogrid system=$system";
+    if ( $useref ) {
+
+      # Compare the molecules and transitions between the observation(s)
+      # being processed and the reference NDF, to advise whether or not
+      # the combination makes sense.
+      orac_say "Aligning the output spectral cube to $refppv.";
+
+      # Check that the current Frame and the reference file are
+      # observations of the same molecule and transition.
+      _COMPARE_SPECIES_ OBJ=$Grp REF=$refppv ABORT=0
 
     } else {
 
-      $Grp->uhdr( "SPARSE", 0 );
+      # Check to see if we have any pixel sizes back from the previous
+      # MAKECUBE runs. If we don't have any, then all of the resulting
+      # cubes will be sparse, so set autogrid=yes and ignore
+      # tiling. Otherwise, we want to find the smallest pixel size and
+      # go with that.
+      if ( scalar values %pixsize == 0 ) {
 
-      # Set arbitrary maximum pixel size in arcseconds.
-      my $pixsize = 1000;
-      if( ! defined( $ppixsize ) ) {
-        foreach my $value ( values %pixsize ) {
-          $pixsize = ( $value > $pixsize ) ? $pixsize : $value;
+        orac_warn "Resulting cube will be sparse.\n";
+        $Grp->uhdr( "SPARSE", 1 );
+        $params = "autogrid system=$system";
+
+      } else {
+
+        $Grp->uhdr( "SPARSE", 0 );
+
+        # Set arbitrary maximum pixel size in arcseconds.
+        $pixsize = 1000;
+        if ( ! defined( $ppixsize ) ) {
+          foreach my $value ( values %pixsize ) {
+            $pixsize = ( $value > $pixsize ) ? $pixsize : $value;
+          }
+
+          # Check the pixel size. If it's smaller than a quarter of the
+          # beamsize, set it to a quarter of the beamsize.
+          my $lofreqs = defined( $Frm->hdr( "LOFREQS" ) ) ?
+                        $Frm->hdr( "LOFREQS" )            :
+                        $Frm->jcmtstate( "FE_LOFREQ" );
+
+          my $min_pixsize = int( FREQ2PIXSIZE / $lofreqs + 0.5 );
+          $pixsize = ( $pixsize < $min_pixsize ) ? $min_pixsize : $pixsize;
+        } else {
+          $pixsize = $ppixsize;
         }
 
-        # Check the pixel size. If it's smaller than a quarter of the
-        # beamsize, set it to a quarter of the beamsize.
-        my $lofreqs = defined( $Frm->hdr( "LOFREQS" ) ) ?
-                      $Frm->hdr( "LOFREQS" )            :
-                      $Frm->jcmtstate( "FE_LOFREQ" );
+        # We have a hash with a bunch of rotation angles in it. Set the
+        # rotation angle to be the average of all of these. Deal with
+        # the wrap-around by averaging the sin and cos instead of the angle.
+        my $sin_a = 0;
+        my $cos_a = 0;
 
-        my $min_pixsize = int( FREQ2PIXSIZE / $lofreqs + 0.5 );
-        $pixsize = ( $pixsize < $min_pixsize ) ? $min_pixsize : $pixsize;
-      } else {
-        $pixsize = $ppixsize;
-      }
+        map { $sin_a += sin( $_ * pi/180.0 ) } values %crota;
+        map { $cos_a += cos( $_ * pi/180.0 ) } values %crota;
 
-      # We have a hash with a bunch of rotation angles in it. Set the
-      # rotation angle to be the average of all of these. Deal with
-      # the wrap-around by averaging the sin and cos instead of the angle.
-      my $sin_a = 0;
-      my $cos_a = 0;
+        $sin_a /= scalar values %crota;
+        $cos_a /= scalar values %crota;
+        $crota = sprintf "%6.2f", atan2($sin_a, $cos_a) * 180.0/pi;
+        $crota =~ s/^\s+//;
+        $crota = 0.00 if ( abs($crota) < 0.2 );
 
-      map { $sin_a += sin( $_ * pi/180.0 ) } values %crota;
-      map { $cos_a += cos( $_ * pi/180.0 ) } values %crota;
-
-      $sin_a /= scalar values %crota;
-      $cos_a /= scalar values %crota;
-      my $crota = sprintf "%6.2f", atan2($sin_a, $cos_a) * 180.0/pi;
-      $crota =~ s/^\s+//;
-      $crota = 0.00 if ( abs($crota) < 0.2 );
-
-      # However! If we have a user-defined system, set the CROTA to 0.
-      if( defined( $system_arg ) ) {
-        $crota = 0;
-      }
-
-      # Find out how big our tiles are going to be.  Since we do not
-      # want the tile dimensions to vary in order to enable tiles from
-      # each chunk to be combined, disable the ability to adjust the
-      # tile dimensions arbitrarily.  This is achieved by setting the
-      # dimension negative.
-      if ( $tile && !$jsatile ) {
-         _GET_TILE_DIMENSIONS_ TILEBORDER=$tileborder MAXSIZE=$maxsize BYTES_PER_PIXEL=$bytes_per_pixel
-         $tiledims = -1 * $_GET_TILE_DIMENSIONS_{TILEDIMS};
-      }
-
-      # Get the parameter string to send to makecube.
-      _GET_SPREAD_PARAMS_ METHOD=$spread PARAM1=$sp_param1 PARAM2=$sp_param2 PIXSIZE=$pixsize
-      $sp_params = $_GET_SPREAD_PARAMS_{PARAMSTRING};
-
-      # Set up MAKECUBE parameters.
-      if ( $sp_params eq  "''" ) {
-         $params  = "pixsize=$pixsize crota=$crota spread=$spread usedetpos=$usedetpos";
-      } else {
-         $params  = "pixsize=$pixsize crota=$crota spread=$spread params=$sp_params usedetpos=$usedetpos";
-      }
-      if ( $tile && ! $jsatile ) {
-         $params .= " tiledims=$tiledims system=$system autogrid tileborder=$tileborder trim=n trimtiles";
-      } elsif ( $jsatile ) {
-         $params .= " system=$system autogrid trim=n jsatiles ";
-      } else {
-         $params .= " tiledims=! system=$system autogrid trim=n";
+        # However! If we have a user-defined system, set the CROTA to 0.
+        if ( defined( $system_arg ) ) {
+          $crota = 0;
+        }
       }
     }
 
-    # Always use badmask=and.
-    $params .= " badmask=and";
+    # Find out how big our tiles are going to be.  Since we do not
+    # want the tile dimensions to vary in order to enable tiles from
+    # each chunk to be combined, disable the ability to adjust the
+    # tile dimensions arbitrarily.  This is achieved by setting the
+    # dimension negative.
+    if ( $tile && !$jsatile ) {
+      _GET_TILE_DIMENSIONS_ TILEBORDER=$tileborder MAXSIZE=$maxsize BYTES_PER_PIXEL=$bytes_per_pixel
+      $tiledims = -1 * $_GET_TILE_DIMENSIONS_{TILEDIMS};
+    }
+
+    # Get the parameter string to send to makecube.
+    _GET_SPREAD_PARAMS_ METHOD=$spread PARAM1=$sp_param1 PARAM2=$sp_param2 PIXSIZE=$pixsize
+    $sp_params = $_GET_SPREAD_PARAMS_{PARAMSTRING};
+
+    # Set up MAKECUBE parameters.
+    if ( $sp_params eq  "''" ) {
+      $params  = "spread=$spread usedetpos=$usedetpos";
+    } else {
+      $params  = "spread=$spread params=$sp_params usedetpos=$usedetpos";
+    }
+
+    if ( $useref ) {
+      $params .= " ref=$refppv";
+      if ( $tile ) {
+        $params .= " tiledims=$tiledims system=$system tileborder=$tileborder trim=n trimtiles";
+      } else {
+        $params .= " tiledims=! system=$system trim=n";
+      }
+
+    } else {
+      $params .= " pixsize=$pixsize crota=$crota";
+      if ( $tile && ! $jsatile ) {
+        $params .= " tiledims=$tiledims system=$system autogrid tileborder=$tileborder trim=n trimtiles";
+      } elsif ( $jsatile ) {
+        $params .= " system=$system autogrid trim=n jsatiles ";
+      } else {
+        $params .= " tiledims=! system=$system autogrid trim=n";
+      }
+    }
+
+    # Always use badmask=and unless with a reference NDF.
+    $params .= " badmask=and" if ( ! $useref );
 
     # Quick hack for hybrid-mode observations.
     if( $Frm->uhdr( "ISHYBRID" ) ) {

--- a/src/primitives/heterodyne/_CREATE_CUBE_GROUP_
+++ b/src/primitives/heterodyne/_CREATE_CUBE_GROUP_
@@ -85,9 +85,9 @@ output group spectral cube will be aligned.  This rarely used option
 permits observations taken with different spectral and/or spatial
 resolutions to be combined later.  The reference cube is normally one
 with wider spectral channels.  This facility does not operate if the
-reference NDF is undefined or the NDF does not exist.  A warning is
-issued if the current group data and the reference NDF do not have
-matching molecules and transitions.
+reference NDF is undefined or the NDF does not exist or if the
+observation is hybrid.  A warning is issued if the current group data
+and the reference NDF do not have matching molecules and transitions.
 
 This argument can be overridden by the RECPAR_REFERENCE_PPV uhdr via
 the recipe parameter system.  [undef]
@@ -181,7 +181,8 @@ Malcolm J. Currie E<lt>mjc@star.rl.ac.ukE<gt>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2008, 2010-2011, 2013-2014 Science and Technology Facilities Council.
+Copyright (C) 2008, 2010-2011, 2013-2014, 2019 Science and Technology
+Facilities Council.
 Copyright (C) 2006-2007 Particle Physics and Astronomy Research Council.
 All Rights Reserved.
 

--- a/src/primitives/heterodyne/_CREATE_CUBE_GROUP_
+++ b/src/primitives/heterodyne/_CREATE_CUBE_GROUP_
@@ -412,7 +412,7 @@ if( $Grp->lastallmembers( $Frm ) ) {
       # Check that the current Frame and the reference file are
       # observations of the same molecule and transition.  Only issue
       # warning if there is a mismatch.
-      _COMPARE_SPECIES_ OBJ=$Grp REF=$refppv ABORT=0
+      _COMPARE_SPECIES_ GROUP=1 REF=$refppv ABORT=0
 
       # Specify the reference cube.
       $params = "ref=$refppv";

--- a/src/primitives/heterodyne/_CREATE_CUBE_GROUP_
+++ b/src/primitives/heterodyne/_CREATE_CUBE_GROUP_
@@ -205,6 +205,9 @@ MA 02111-1307, USA.
 
 =cut
 
+# Definitions
+# ===========
+
 use Math::Trig;
 use File::Copy;
 
@@ -220,6 +223,8 @@ use constant MEGABYTE => 1048576;
 use constant JSACHUNK => 1000;
 
 # Deal with parameters.
+# =====================
+
 my $system_arg = get_prim_arg( $_PRIM_ARGS_, "SYSTEM", undef );
 my $spread = uc( get_prim_arg( $_PRIM_ARGS_, "SPREAD", 'NEAREST' ) );
 my $sp_param1 = get_prim_arg( $_PRIM_ARGS_, "PARAM1", 0 );
@@ -274,6 +279,9 @@ $chunksize = JSACHUNK if $jsatile;
 # internally.
 my $tileborder = 0;
 
+# Main processing begins here.
+# ============================
+
 # Only process if we're on the last member of a group.
 if( $Grp->lastallmembers( $Frm ) ) {
 
@@ -318,6 +326,9 @@ if( $Grp->lastallmembers( $Frm ) ) {
 
     # Create the command-line parameters for MAKECUBE.
     # ================================================
+
+    # Obtain the WCS and the source of the detector positions.
+    # --------------------------------------------------------
 
     # We want to go through each member Frm in the Grp and determine
     # the MAKECUBE parameters individually. Then, we'll take the
@@ -399,6 +410,9 @@ if( $Grp->lastallmembers( $Frm ) ) {
     my $pixsize;
     my $crota;
 
+    # Form the list of WCS-related MAKECUBE parameter values.
+    # -------------------------------------------------------
+
     # This MAKECUBE command line will be assembled in this string.
     my $params = "";
 
@@ -474,6 +488,9 @@ if( $Grp->lastallmembers( $Frm ) ) {
         }
       }
     }
+
+    # Obtain other attributes needed to assign MAKECUBE parameter settings.
+    # ---------------------------------------------------------------------
 
     # Find out how big our tiles are going to be.  Since we do not
     # want the tile dimensions to vary in order to enable tiles from

--- a/src/primitives/heterodyne/_CREATE_CUBE_GROUP_
+++ b/src/primitives/heterodyne/_CREATE_CUBE_GROUP_
@@ -347,43 +347,40 @@ if( $Grp->lastallmembers( $Frm ) ) {
       my $mc_hash = $_GET_MAKECUBE_PARAMS_{HASH};
       $mc_params .= " jsatiles" if $jsatile;
 
-      if( lc( $obstype ) ne 'raster' ) {
+      # If we're not doing a raster, then we have to run MAKECUBE in
+      # autogrid, then determine the pixel scale from the result of
+      # that. _GET_MAKECUBE_PARAMS_ returns autogrid=yes for
+      # anything that isn't a raster.
+      if ( ! $useref ) {
+        if ( lc( $obstype ) ne 'raster' ) {
+          my $inlist = write_file_list ( $Frm->files );
 
-        # If we're not doing a raster, then we have to run MAKECUBE in
-        # autogrid, then determine the pixel scale from the result of
-        # that. _GET_MAKECUBE_PARAMS_ returns autogrid=yes for
-        # anything that isn't a raster.
+          orac_print "Determining parameters for output cube...";
+          $Mon{'smurf_mon'}->obeyw( "makecube", "$mc_params in='^$inlist' out=!" );
+          orac_print "done.\n";
 
-        my $inlist = write_file_list ( $Frm->files );
+          # Get the returned pixsize and crota, but only if this isn't a
+          # sparse cube.
+          my ( $ORAC_STATUS, $sparse ) = $Mon{'smurf_mon'}->get( "makecube", "sparse" );
+          if ( uc( $sparse ) eq 'FALSE' ) {
+            ( $ORAC_STATUS, my $pixsize ) = $Mon{'smurf_mon'}->get( "makecube", "pixsize" );
+            ( $ORAC_STATUS, my $crota ) = $Mon{'smurf_mon'}->get( "makecube", "crota" );
 
-        orac_print "Determining parameters for output cube...";
-        $Mon{'smurf_mon'}->obeyw( "makecube", "$mc_params in='^$inlist' out=!" );
-        orac_print "done.\n";
+            # Stick these into the hash.
+            $pixsize{$Frm->file(1)} = $pixsize;
+            $crota{$Frm->file(1)} = $crota;
+          }
+        } else {
 
-        # Get the returned pixsize and crota, but only if this isn't a
-        # sparse cube.
-        my ( $ORAC_STATUS, $sparse ) = $Mon{'smurf_mon'}->get( "makecube", "sparse" );
-        if( uc( $sparse ) eq 'FALSE' ) {
-          ( $ORAC_STATUS, my $pixsize ) = $Mon{'smurf_mon'}->get( "makecube", "pixsize" );
-          ( $ORAC_STATUS, my $crota ) = $Mon{'smurf_mon'}->get( "makecube", "crota" );
-
-          # Stick these into the hash.
-          $pixsize{$Frm->file(1)} = $pixsize;
-          $crota{$Frm->file(1)} = $crota;
+          # Raster parameters come directly from the
+          # _GET_MAKECUBE_PARAMS_ primitive results.
+          $pixsize{$Frm->file} = ( defined( $ppixsize ) ? $ppixsize : $mc_hash->{pixsize} );
+          $crota{$Frm->file} = $mc_hash->{crota};
         }
-      } else {
-
-        # Raster parameters come directly from the
-        # _GET_MAKECUBE_PARAMS_ primitive results.
-        $pixsize{$Frm->file} = ( defined( $ppixsize ) ? $ppixsize : $mc_hash->{pixsize} );
-        $crota{$Frm->file} = $mc_hash->{crota};
       }
       $usedetpos{$Frm->file(1)} = defined( $mc_hash->{usedetpos} ) ? $mc_hash->{usedetpos} : 'no';
       $system{$Frm->file(1)} = $mc_hash->{system};
     }
-
-    # Define a variable that'll hold parameters to MAKECUBE.
-    my $params = '';
 
     # We have a hash with a bunch of systems in it. If they're all the
     # same, use that. Otherwise set the system to 'ICRS'.
@@ -402,8 +399,8 @@ if( $Grp->lastallmembers( $Frm ) ) {
     my $pixsize;
     my $crota;
 
-    # Is there a reference cube to define the WCS?
-    my $useref = defined $refppv && -e $refppv;
+    # This MAKECUBE command line will be assembled in this string.
+    my $params = "";
 
     if ( $useref ) {
 
@@ -413,8 +410,12 @@ if( $Grp->lastallmembers( $Frm ) ) {
       orac_say "Aligning the output spectral cube to $refppv.";
 
       # Check that the current Frame and the reference file are
-      # observations of the same molecule and transition.
+      # observations of the same molecule and transition.  Only issue
+      # warning if there is a mismatch.
       _COMPARE_SPECIES_ OBJ=$Grp REF=$refppv ABORT=0
+
+      # Specify the reference cube.
+      $params = "ref=$refppv";
 
     } else {
 
@@ -490,19 +491,20 @@ if( $Grp->lastallmembers( $Frm ) ) {
 
     # Set up MAKECUBE parameters.
     if ( $sp_params eq  "''" ) {
-      $params  = "spread=$spread usedetpos=$usedetpos";
+      $params .= " spread=$spread usedetpos=$usedetpos";
     } else {
-      $params  = "spread=$spread params=$sp_params usedetpos=$usedetpos";
+      $params .= " spread=$spread params=$sp_params usedetpos=$usedetpos";
     }
 
+    # No WCS parameters needed here.
     if ( $useref ) {
-      $params .= " ref=$refppv";
       if ( $tile ) {
         $params .= " tiledims=$tiledims system=$system tileborder=$tileborder trim=n trimtiles";
       } else {
         $params .= " tiledims=! system=$system trim=n";
       }
 
+    # Apply the WCS values determined earlier.
     } else {
       $params .= " pixsize=$pixsize crota=$crota";
       if ( $tile && ! $jsatile ) {
@@ -514,8 +516,11 @@ if( $Grp->lastallmembers( $Frm ) ) {
       }
     }
 
-    # Always use badmask=and unless with a reference NDF.
-    $params .= " badmask=and" if ( ! $useref );
+    # Always use badmask=and unless working with a reference NDF.
+    if ( $useref ) {
+      $params .= " badmask=or";
+    } else {
+      $params .= " badmask=and";
 
     # Quick hack for hybrid-mode observations.
     if( $Frm->uhdr( "ISHYBRID" ) ) {

--- a/src/primitives/heterodyne/_REDUCE_SCIENCE_GRADIENT_STEER_
+++ b/src/primitives/heterodyne/_REDUCE_SCIENCE_GRADIENT_STEER_
@@ -121,6 +121,7 @@ ORAC::Recipe::Parameters::verify_parameters( \%RECPARS, [ 'BASELINE_EDGES',
                                                           'REF_EMISSION_COMBINE_REFPOS',
                                                           'REF_EMISSION_MASK_SOURCE',
                                                           'REF_EMISSION_REGIONS',
+                                                          'REFERENCE_PPV',
                                                           'RESTRICT_LOWER_VELOCITY',
                                                           'RESTRICT_UPPER_VELOCITY',
                                                           'SPATIAL_SMOOTH',
@@ -315,6 +316,11 @@ if ( defined( $RECPARS{'SPREAD_WIDTH'} ) ) {
 if ( defined( $RECPARS{'SPREAD_FWHM_OR_ZERO'} ) ) {
   $Frm->uhdr( "RECPAR_PARAM2", $RECPARS{'SPREAD_FWHM_OR_ZERO'} );
   orac_say( " Setting MAKECUBE spread FWHM or zero to $RECPARS{'SPREAD_FWHM_OR_ZERO'} arcseconds.", "yellow" );
+}
+
+if ( defined( $RECPARS{'REFERENCE_PPV'} ) ) {
+  $Frm->uhdr( "RECPAR_REFERENCE_PPV", $RECPARS{'REFERENCE_PPV'} );
+  orac_say( " MAKECUBE aims to use $RECPARS{'REFERENCE_PPV'} to define the grid for the group PPV cube.", "yellow" );
 }
 
 if ( defined( $RECPARS{'TILE'} ) ) {

--- a/src/primitives/heterodyne/_REDUCE_SCIENCE_NARROWLINE_STEER_
+++ b/src/primitives/heterodyne/_REDUCE_SCIENCE_NARROWLINE_STEER_
@@ -124,6 +124,7 @@ ORAC::Recipe::Parameters::verify_parameters( \%RECPARS, [ 'BASELINE_EDGES',
                                                           'REF_EMISSION_COMBINE_REFPOS',
                                                           'REF_EMISSION_MASK_SOURCE',
                                                           'REF_EMISSION_REGIONS',
+                                                          'REFERENCE_PPV',
                                                           'RESTRICT_LOWER_VELOCITY',
                                                           'RESTRICT_UPPER_VELOCITY',
                                                           'SPATIAL_SMOOTH',
@@ -300,6 +301,11 @@ if ( defined( $RECPARS{'SPREAD_WIDTH'} ) ) {
 if ( defined( $RECPARS{'SPREAD_FWHM_OR_ZERO'} ) ) {
   $Frm->uhdr( "RECPAR_PARAM2", $RECPARS{'SPREAD_FWHM_OR_ZERO'} );
   orac_say( " Setting MAKECUBE spread FWHM or zero to $RECPARS{'SPREAD_FWHM_OR_ZERO'} arcseconds.", "yellow" );
+}
+
+if ( defined( $RECPARS{'REFERENCE_PPV'} ) ) {
+  $Frm->uhdr( "RECPAR_REFERENCE_PPV", $RECPARS{'REFERENCE_PPV'} );
+  orac_say( " MAKECUBE aims to use $RECPARS{'REFERENCE_PPV'} to define the grid for the group PPV cube.", "yellow" );
 }
 
 if ( defined( $RECPARS{'TILE'} ) ) {


### PR DESCRIPTION
JanW wanted to combine reduced ACSIS spectral cubes of different spectral
resolutions in KAPPA.  While this was possible, there was image degradation
using WCSMOSAIC. @dsberry advanced a better approach using the
REF=_file_ feature of MAKECUBE.

I thought that it would be handy to make ORAC-DR heterodyne recipes
support this feature.  This branch does that.  It  enables a reference grid to
be defined via a REFERENCE_PPV recipe parameter (and a argument to
`_CREATE_CUBE_GROUP_`).  It has been tested on the most commonly used
recipes (`REDUCE_SCIENCE_GRADIENT` and `REDUCE_SCIENCE_NARROWLINE`),
but as some commonly used code had to be restructured, this feature does
need further evaluation, and checks that other recipes and processing of
hybrid data are not compromised. @sfgraves please could you install this
 so that JanW can perform some testing.

The difference in quality can be seen in this test representative image that
combines data of different resolutions.  The left panel shows an ORAC-DR 
reduction using the new reference-grid feature, and the right combines 
reduced spectral cubes with WCSMOSAIC.

![ref_vs_wcsmosaic](https://user-images.githubusercontent.com/113052/53916228-83dbd500-4059-11e9-938c-c84bf282731a.png)
