### PR TITLE
Calib: Validate receptor names by instrument in list system.

### DIFF
--- a/src/lib/perl5/ORAC/Calib/ACSIS.pm
+++ b/src/lib/perl5/ORAC/Calib/ACSIS.pm
@@ -580,7 +580,7 @@ Malcolm J. Currie <mjc@jach.hawaii.edu>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2007-2009, 2014, 2016 Science and Technology Facilities Council.
+Copyright (C) 2007-2009, 2014, 2016, 2020 Science and Technology Facilities Council.
 All Rights Reserved.
 
 =cut

--- a/src/lib/perl5/ORAC/Calib/ACSIS.pm
+++ b/src/lib/perl5/ORAC/Calib/ACSIS.pm
@@ -459,7 +459,7 @@ sub receptor_names {
       @receptors = ( "CA", "CB", "DA", "DB" );
 
     } elsif ( $instrument eq /UU/ ) {
-      @receptors = ( "HUOL", "HU1L", "HU0U", "HU1L" );
+      @receptors = ( "NU0L", "NU1L", "NU0U", "NU1U" );
 
     } elsif ( $instrument eq "AWEOWEO" ) {
       @receptors = ( "NW0L", "NW0U", "NW1L", "NW1U" );


### PR DESCRIPTION
The --calib bad_receptors= command-line syntax permits additional
receptors to be flagged as bad, in the so-called list system.
ORAC::Calib::ACSIS tested that the supplied receptors were valid, but
was only comparing with the HARP set H00..H15.  I've added a new
method, receptor_names, which checks against appropriate receptors
names for the various current, historical, and upcoming Namakanui
instruments.  If a invalid receptor is supplied, it now issues a
warning rather than silently continuing leaving the ORAC-DR user
puzzled or none the wiser.

We should look for other places where the receptor name is assumed to
be H00..H15.